### PR TITLE
Pause across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The options are:
 2. **Scheduler**
   * *Application Clock Tick Time*: represents the tick frequency of the application clock, sort of a heartbeat, each tick verifies whether or not a condition has to be checked; this option is called `tick seconds` in the configuration file
   * *Condition Check Skip Time*: all conditions will skip this amount of seconds from previous test to perform an actual test, should be at least the same as *Application Clock Tick Time*; this is named `skip seconds` in the configuration file.
+  * *Preserve Pause Across Sessions*: if *true* (the default) the scheduler will remain paused upon applet restart if it was paused when the applet (or session) was closed. Please notice that the indicator icon gives feedback anyway about the paused/non-paused state.
 3. **Advanced**
   * *Max Concurrent Tasks*: maximum number of tasks that can be run in a parallel run (`max threads` in the configuration file)
   * *Log Level*: the amount of detail in the log file
@@ -108,6 +109,7 @@ By default the applet creates a file with the following configuration, which sho
 [Scheduler]
 tick seconds = 15
 skip seconds = 60
+preserve pause = true
 
 [General]
 show icon = true

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The options are:
 2. **Scheduler**
   * *Application Clock Tick Time*: represents the tick frequency of the application clock, sort of a heartbeat, each tick verifies whether or not a condition has to be checked; this option is called `tick seconds` in the configuration file
   * *Condition Check Skip Time*: all conditions will skip this amount of seconds from previous test to perform an actual test, should be at least the same as *Application Clock Tick Time*; this is named `skip seconds` in the configuration file.
-  * *Preserve Pause Across Sessions*: if *true* (the default) the scheduler will remain paused upon applet restart if it was paused when the applet (or session) was closed. Please notice that the indicator icon gives feedback anyway about the paused/non-paused state.
+  * *Preserve Pause Across Sessions*: if *true* (the default) the scheduler will remain paused upon applet restart if it was paused when the applet (or session) was closed. Please notice that the indicator icon gives feedback anyway about the paused/non-paused state. Use `preserve pause` in the configuration file.
 3. **Advanced**
   * *Max Concurrent Tasks*: maximum number of tasks that can be run in a parallel run (`max threads` in the configuration file)
   * *Log Level*: the amount of detail in the log file

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The options are:
   * *Icon Theme*: `Guess` to let the application decide, otherwise one of `Dark` (light icons for dark themes), `Light` (dark icons for light themes), and `Color` for colored icons that should be visible on all themes.
 2. **Scheduler**
   * *Application Clock Tick Time*: represents the tick frequency of the application clock, sort of a heartbeat, each tick verifies whether or not a condition has to be checked; this option is called `tick seconds` in the configuration file
-  * *Condition Check Skip Time*: all conditions will skip this amount of seconds from previous test to perform an actual test, should be at least the same as *Application Clock Tick Time*; this is named `skip seconds` in the configuration file.
+  * *Condition Check Skip Time*: all conditions will skip this amount of seconds from previous test to perform an actual test, should be at least the same as *Application Clock Tick Time*; this is named `skip seconds` in the configuration file
   * *Preserve Pause Across Sessions*: if *true* (the default) the scheduler will remain paused upon applet restart if it was paused when the applet (or session) was closed. Please notice that the indicator icon gives feedback anyway about the paused/non-paused state. Use `preserve pause` in the configuration file.
 3. **Advanced**
   * *Max Concurrent Tasks*: maximum number of tasks that can be run in a parallel run (`max threads` in the configuration file)

--- a/share/when-command-settings.glade
+++ b/share/when-command-settings.glade
@@ -259,6 +259,35 @@
                         <property name="height">1</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkFixed" id="fixSpacer">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                        <property name="width">2</property>
+                        <property name="height">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="chkPreservePause">
+                        <property name="label" translatable="yes">Preserve Pause Across Sessions</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.49000000953674316</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">3</property>
+                        <property name="width">2</property>
+                        <property name="height">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/when-command.py
+++ b/when-command.py
@@ -274,7 +274,7 @@ def create_autostart_file(overwrite=True):
 # manage pause file
 def create_pause_file():
     if not os.path.exists(USER_PAUSE_FILE):
-        file(USER_PAUSE_FILE, 'w')
+        open(USER_PAUSE_FILE, 'w')
         return True
     else:
         return False

--- a/when-command.py
+++ b/when-command.py
@@ -81,6 +81,7 @@ USER_CONFIG_FOLDER = os.path.join(USER_FOLDER, '.config', APPLET_NAME)
 USER_LOG_FOLDER = os.path.join(USER_DATA_FOLDER, 'log')
 USER_LOG_FILE = os.path.join(USER_LOG_FOLDER, "%s.log" % APPLET_NAME)
 USER_CONFIG_FILE = os.path.join(USER_CONFIG_FOLDER, "%s.conf" % APPLET_NAME)
+USER_PAUSE_FILE = os.path.join(USER_CONFIG_FOLDER, "%s.pause" % APPLET_NAME)
 
 
 # verify that the user folders are present, otherwise create them
@@ -268,6 +269,27 @@ def create_autostart_file(overwrite=True):
                 applet_log.error("MAIN: could not create the autostart launcher")
 
 
+# manage pause file
+def create_pause_file():
+    if not os.path.exists(USER_PAUSE_FILE):
+        file(USER_PAUSE_FILE, 'w')
+        return True
+    else:
+        return False
+
+
+def check_pause_file():
+    return os.path.exists(USER_PAUSE_FILE)
+
+
+def unlink_pause_file():
+    if os.path.exists(USER_PAUSE_FILE):
+        os.unlink(USER_PAUSE_FILE)
+        return True
+    else:
+        return False
+
+
 # logger
 applet_log_handler = logging.NullHandler()
 applet_log_formatter = logging.Formatter(fmt=LOG_FORMAT, datefmt="%Y-%m-%d %H:%M:%S")
@@ -343,6 +365,7 @@ class Config(object):
             'Scheduler': {
                 'tick seconds': int,
                 'skip seconds': int,
+                'preserve pause': bool_spec,
             },
             'General': {
                 'show icon': bool_spec,
@@ -366,6 +389,7 @@ class Config(object):
             [Scheduler]
             tick seconds = 15
             skip seconds = 60
+            preserve pause = true
 
             [General]
             show icon = true


### PR DESCRIPTION
The code here allows for pause state preservation across sessions: also a quirk was spotted, where the scheduler started autonomously due to an "autostart switch" which was turned on by default. This has been corrected. Also, using the scheduler status as a flag, conditions that aren't bound to the scheduler (namely, *event based* conditions for the moment) are skipped when the applet is paused: this seems a more consistent behaviour than letting these conditions out of control.

F.