### PR TITLE
Command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ log size = 1048576
 log backups = 4
 ```
 
-Manual configuration is particularly useful to bring back the program icon once the user decided to hide it (losing access to the menu: I was doubtful about providing the option, then just decided to implement it and provide a safety net anyway), by setting the `show icon` entry to `true`. Another way to force access to the *Settings* dialog box when the icon is hidden is to explicitly invoke the applet (either from the command line, or the Gnome shell, or *Dash* on Ubuntu) when an instance is already running. However, in this case, *after the dialog box is closed, the running instance will shut down and will have to be restarted*.
+Manual configuration is particularly useful to bring back the program icon once the user decided to hide it (losing access to the menu: I was doubtful about providing the option, then just decided to implement it and provide a safety net anyway), by setting the `show icon` entry to `true`. Another way to force access to the *Settings* dialog box when the icon is hidden is to invoke the applet from the command line using the `--show-settings` (or `-S`) switch when an instance is running.
 
 
 ### Installation requirements and Directory structure

--- a/README.md
+++ b/README.md
@@ -134,24 +134,24 @@ Manual configuration is particularly useful to bring back the program icon once 
 
 By default, when the applet is invoked with no arguments, it just starts an instance showing the icon in the top panel (if configured to do so). However there are some command line options that allow for some operations, either on a running instance or on the current configuration. Some are especially useful to recover when something has gone the wrong way -- such as the `-S` switch mentioned above, or the `-I` (or `--show-icon`) switch, to recover from an unwantedly hidden icon. The available options are:
 
-* `-S` or `--show-settings`: show the settings dialog box of an existing instance, it requires in fact that an instance is running, which may be queried using the `--query` switch explained below
-* `-R` or `--reset-config`: reset applet configuration to default, requires the applet to be not running or to be shut down with an appropriate switch
-* `-I` or `--show-icon`: show applet icon at the next startup
-* `-T` or `--install`: install or reinstall application icon and autostart icon, requires applet to be not running or to be shut down with an appropriate switch
-* `-C` or `--clear`: clear current tasks and conditions, requires applet to be not running or to be shut down with an appropriate switch
+* `-S` or `--show-settings`: show the settings dialog box of an existing instance, it requires a running instance, which may be queried using the `--query` switch explained below
+* `-R` or `--reset-config`: reset applet configuration to default, requires the applet to be shut down with an appropriate switch
+* `-I` or `--show-icon`: show applet icon, the icon will be shown at the next startup
+* `-T` or `--install`: install or reinstall application icon and autostart icon, requires applet to be shut down with an appropriate switch
+* `-C` or `--clear`: clear current tasks and conditions, requires applet to be shut down with an appropriate switch
 * `-Q` or `--query`: query for an existing instance (returns a zero exit status if an instance is running, nonzero otherwise, and prints an human-readable message if the `--verbose` switch is also specified)
-* `--shutdown`: close a running instance as if *Quit* was selected from the menu, that is performing all shutdown tasks first
-* `--kill`: close a running instance abruptly, no shutdown tasks are performed
+* `--shutdown`: close a running instance performing shutdown tasks first
+* `--kill`: close a running instance abruptly, no shutdown tasks are run
 * `--export` *[filename]*: save tasks and conditions to a portable format, if *filename* is not specified these items are saved in a default file in the `~/.config/when-command` directory
-* `--import` *[filename]*: clear tasks and conditions and import them from a previously saved file, if *filename* is not specified the applet tries to import these items from the default file in the `~/.config/when-command` directory.
+* `--import` *[filename]*: clear tasks and conditions and import them from a previously saved file, if *filename* is not specified the applet tries to import these items from the default file in the `~/.config/when-command` directory; the applet has to be shut down before attempting to import tasks and conditions.
 
-Some usual switches are also available:
+Some trivial switches are also available:
 
 * `-h` or `--help`: show a brief help message and exit
 * `-V` or `--version`: show applet version, if `--verbose` is specified it also shows the *About Box* of a running instance, if there is one
 * `-v` or `--verbose`: show output for some options; normally the applet would not display any output to the terminal unless `-v` is specified, the only exception being `--version` that prints out the version string anyway.
 
-Please note that whenever a command line option is given, the applet will not "stay resident" if there is no previously running instance.
+Please note that whenever a command line option is given, the applet will not "stay resident" if there is no previously running instance. On the other side, if the user invokes the applet when already running, the new instance will bail out with an error.
 
 
 ### Installation requirements and Directory structure

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ By default, when the applet is invoked with no arguments, it just starts an inst
 * `-Q` or `--query`: query for an existing instance (returns a zero exit status if an instance is running, nonzero otherwise, and prints an human-readable message if the `--verbose` switch is also specified)
 * `--shutdown`: close a running instance performing shutdown tasks first
 * `--kill`: close a running instance abruptly, no shutdown tasks are run
-* `--export` *[filename]*: save tasks and conditions to a portable format, if *filename* is not specified these items are saved in a default file in the `~/.config/when-command` directory
+* `--export` *[filename]*: save tasks and conditions to a portable format, if *filename* is not specified these items are saved in a default file in the `~/.config/when-command` directory; this will especially be useful in cases where the compatibility of the "running" versions of tasks and conditions (which are a binary format) could be broken across releases
 * `--import` *[filename]*: clear tasks and conditions and import them from a previously saved file, if *filename* is not specified the applet tries to import these items from the default file in the `~/.config/when-command` directory; the applet has to be shut down before attempting to import tasks and conditions.
 
 Some trivial switches are also available:
@@ -210,9 +210,9 @@ A more general discussion about contribution can be found [here](https://help.gi
 
 ### Breaking the compatibility
 
-As long as the software can be considered in its *pre-release* state, breaking the backwards-compatibility is allowed although undesirable. **When** has actually been released as *beta* software, since it has been tested for a while and with a suite that covered all the cases it can handle. Probably there are still bugs and they will have to be corrected. Unfortunately these bugs could also pop up in the two main classes that build the core of the applet, and the "form" of these classes could affect the way the stateful part of the program data (namely, *Tasks* and *Conditions*) is stored to disk: when it comes to bugs, until **When** enters a *production* state (which will be the 1.0.0 release, as per the [Semantic Versioning](https://github.com/mojombo/semver/blob/master/semver.md) specification), compatibility break will be preferred to bug persistence. In all other cases I'll grant special attention to the possibility to install newer versions of the software without having to redefine all rules.
+As long as the software can be considered in its *pre-release* state, breaking the backwards-compatibility is allowed although undesirable. **When** has actually been released as *beta* software, since it has been tested for a while and with a suite that covered all the cases it can handle. Probably there are still bugs and they will have to be corrected. Unfortunately these bugs could also pop up in the two main classes that build the core of the applet, and the "form" of these classes could affect the way the stateful part of the program data (namely, *Tasks* and *Conditions*) is stored to disk: when it comes to bugs, until **When** enters a *production* state (which will be the 1.0.0 release, as per the [Semantic Versioning](https://github.com/mojombo/semver/blob/master/semver.md) specification), compatibility break will be preferred to bug persistence or bad design. Also considering that starting with release *0.5.0-beta.1* a mechanism is provided to save persistent data to a portable format that would remain valid across releases (via the `--import` and `--export` command line switches); it's advisable, while **When** is still in its early development stage, to perform an export whenever the configuration changes, in order to be able to recover if the applet is unable to start due to compatibility mismatch. All users that access **When** on the host system should take care to export their data periodically, so that when the administrator updates the package they could recover in the same way.
 
-However, there have been some changes that actually broke the backwards compatibility: explicit variables were instead of properties and setters/getters in the main classes, to improve readability and clarity of code. *Tasks* and *Conditions* (and other configuration parts) created with the 0.1.x releases are not compatible with the ones that are created with version 0.2.x (and further). Until another way of saving tasks and conditions is found, or at least to dump/restore them in a portable form, no other compatibility breaks should occur.
+There have been some changes that actually broke the backwards compatibility, without the possibility to recover: explicit variables are now used instead of properties and setters/getters in the main classes, to improve readability and clarity of code. *Tasks* and *Conditions* (and other configuration parts) created with the 0.1.x releases are not compatible with the ones that are created with version 0.2.x (and further). Releases *0.2.0* through *0.5.0-beta.1* are compatible with each other.
 
 
 ### Resources
@@ -224,6 +224,7 @@ This software is designed to run mainly on Ubuntu, so the chosen framework is *P
 * [PyGTK 2.x Documentation](https://developer.gnome.org/pygtk/stable/)
 * [PyGObject Documentation](https://developer.gnome.org/pygobject/stable/)
 * [GTK 3.0 Documentation](http://lazka.github.io/pgi-docs/Gtk-3.0/index.html)
+* [DBus Documentation](http://www.freedesktop.org/wiki/Software/dbus/)
 
 The top panel icons and the emblems used in the application were selected within Google's [Material Design](https://materialdesignicons.com/) icon collection.
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,30 @@ log backups = 4
 Manual configuration is particularly useful to bring back the program icon once the user decided to hide it (losing access to the menu: I was doubtful about providing the option, then just decided to implement it and provide a safety net anyway), by setting the `show icon` entry to `true`. Another way to force access to the *Settings* dialog box when the icon is hidden is to invoke the applet from the command line using the `--show-settings` (or `-S`) switch when an instance is running.
 
 
+### Command line options
+
+By default, when the applet is invoked with no arguments, it just starts an instance showing the icon in the top panel (if configured to do so). However there are some command line options that allow for some operations, either on a running instance or on the current configuration. Some are especially useful to recover when something has gone the wrong way -- such as the `-S` switch mentioned above, or the `-I` (or `--show-icon`) switch, to recover from an unwantedly hidden icon. The available options are:
+
+* `-S` or `--show-settings`: show the settings dialog box of an existing instance, it requires in fact that an instance is running, which may be queried using the `--query` switch explained below
+* `-R` or `--reset-config`: reset applet configuration to default, requires the applet to be not running or to be shut down with an appropriate switch
+* `-I` or `--show-icon`: show applet icon at the next startup
+* `-T` or `--install`: install or reinstall application icon and autostart icon, requires applet to be not running or to be shut down with an appropriate switch
+* `-C` or `--clear`: clear current tasks and conditions, requires applet to be not running or to be shut down with an appropriate switch
+* `-Q` or `--query`: query for an existing instance (returns a zero exit status if an instance is running, nonzero otherwise, and prints an human-readable message if the `--verbose` switch is also specified)
+* `--shutdown`: close a running instance as if *Quit* was selected from the menu, that is performing all shutdown tasks first
+* `--kill`: close a running instance abruptly, no shutdown tasks are performed
+* `--export` *[filename]*: save tasks and conditions to a portable format, if *filename* is not specified these items are saved in a default file in the `~/.config/when-command` directory
+* `--import` *[filename]*: clear tasks and conditions and import them from a previously saved file, if *filename* is not specified the applet tries to import these items from the default file in the `~/.config/when-command` directory.
+
+Some usual switches are also available:
+
+* `-h` or `--help`: show a brief help message and exit
+* `-V` or `--version`: show applet version, if `--verbose` is specified it also shows the *About Box* of a running instance, if there is one
+* `-v` or `--verbose`: show output for some options; normally the applet would not display any output to the terminal unless `-v` is specified, the only exception being `--version` that prints out the version string anyway.
+
+Please note that whenever a command line option is given, the applet will not "stay resident" if there is no previously running instance.
+
+
 ### Installation requirements and Directory structure
 
 For the applet to function and before unpacking it to the destination directory, make sure that *Python 3.x*,  *PyGObject* for *Python 3.x* and the `xprintidle` utility are installed. For example, not all of these are installed by default on Ubuntu: in this case use the following commands.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,6 +67,16 @@ List of achievements and expectations for the When applet.
 * Ubuntu/Debian package :ok:
 * Refactoring: instance variables instead of properties and setters :ok:
 * Dialog box design and refactoring :ok:
+* Command line switches (and configuration maintenance) :+1:
+  - Close current instance :ok:
+  - Open settings dialog :ok:
+  - Clear/Rebuild configuration directory :ok:
+  - Rewrite configuration :ok:
+  - Rewrite configuration and exit (via 2 switches) :ok:
+  - Install icons :ok:
+  - Force indicator icon on :ok:
+  - export tasks and conditions :ok:
+  - import tasks and conditions :ok:
 
 
 ## 2) To *Working* Alpha Release
@@ -86,16 +96,6 @@ List of achievements and expectations for the When applet.
 
 ## 5) To 1.0 *Production* Release
 
-* Command line switches (and configuration maintenance)
-  - Close current instance :ok:
-  - Open settings dialog :ok:
-  - Clear/Rebuild configuration directory :ok:
-  - Rewrite configuration :ok:
-  - Rewrite configuration and exit (via 2 switches) :ok:
-  - Install icons :ok:
-  - Force indicator icon on ss
-  - export tasks and conditions ss
-  - import tasks and conditions ss
 * Regexp match for shell command results (in both tasks and conditions)
 * More system and session event conditions
   - System suspend and/or resume

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,7 +87,7 @@ List of achievements and expectations for the When applet.
 ## 5) To 1.0 *Production* Release
 
 * Command line switches (and configuration maintenance)
-  - Close current instance ss
+  - Close current instance :ok:
   - Restart current instance ss
   - Start and open settings dialog ss
   - Clear/Rebuild configuration directory

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,14 +88,14 @@ List of achievements and expectations for the When applet.
 
 * Command line switches (and configuration maintenance)
   - Close current instance :ok:
-  - Restart current instance ss
-  - Start and open settings dialog ss
-  - Clear/Rebuild configuration directory
-  - Clear/Rebuild data directory
-  - Rewrite configuration ss
-  - Rewrite configuration and exit (via 2 switches)
-  - Install icons and exit ss
+  - Open settings dialog :ok:
+  - Clear/Rebuild configuration directory :ok:
+  - Rewrite configuration :ok:
+  - Rewrite configuration and exit (via 2 switches) :ok:
+  - Install icons :ok:
   - Force indicator icon on ss
+  - export tasks and conditions ss
+  - import tasks and conditions ss
 * Regexp match for shell command results (in both tasks and conditions)
 * More system and session event conditions
   - System suspend and/or resume

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,15 +87,15 @@ List of achievements and expectations for the When applet.
 ## 5) To 1.0 *Production* Release
 
 * Command line switches (and configuration maintenance)
-  - Close current instance
-  - Restart current instance
-  - Start and open settings dialog
+  - Close current instance ss
+  - Restart current instance ss
+  - Start and open settings dialog ss
   - Clear/Rebuild configuration directory
   - Clear/Rebuild data directory
-  - Rewrite configuration
-  - Rewrite configuration and exit
-  - Install icons and exit
-  - Force indicator icon on
+  - Rewrite configuration ss
+  - Rewrite configuration and exit (via 2 switches)
+  - Install icons and exit ss
+  - Force indicator icon on ss
 * Regexp match for shell command results (in both tasks and conditions)
 * More system and session event conditions
   - System suspend and/or resume

--- a/when-command.py
+++ b/when-command.py
@@ -67,7 +67,9 @@ from collections import OrderedDict, deque, namedtuple
 APPLET_NAME = 'when-command'
 APPLET_FULLNAME = "When Gnome Scheduler"
 APPLET_SHORTNAME = "When"
-APPLET_VERSION = "0.4.1-beta.2"
+APPLET_COPYRIGHT = "(c) 2015 Francesco Garosi"
+APPLET_URL = "http://almostearthling.github.io/when-command/"
+APPLET_VERSION = "0.4.1-beta.3"
 APPLET_ID = "it.jks.WhenCommand"
 APPLET_BUS_NAME = '%s.BusService' % APPLET_ID
 APPLET_BUS_PATH = '/' + APPLET_BUS_NAME.replace('.', '/')
@@ -216,6 +218,30 @@ resources.LISTCOL_HISTORY_SUCCESS = "Result"
 resources.LISTCOL_HISTORY_REASON = "Reason"
 resources.LISTCOL_HISTORY_ROWID = "Row ID"
 
+resources.COMMAND_LINE_HELP_VERSION = "show applet version"
+resources.COMMAND_LINE_HELP_SHOW_SETTINGS = "show settings dialog box for the running instance [R]"
+resources.COMMAND_LINE_HELP_RESET_CONFIG = "reset general configuration to default [S]"
+resources.COMMAND_LINE_HELP_SHOW_ICON = "show applet icon [N]"
+resources.COMMAND_LINE_HELP_CLEAR = "clear all tasks and conditions [S]"
+resources.COMMAND_LINE_HELP_INSTALL = "install application icons and autostart [S]"
+resources.COMMAND_LINE_HELP_QUERY = "query for a running instance"
+resources.COMMAND_LINE_HELP_SHUTDOWN = "run shutdown tasks and close an existing istance [R]"
+resources.COMMAND_LINE_HELP_KILL = "kill an existing istance [R]"
+resources.COMMAND_LINE_HELP_EXPORT = "save tasks and conditions to a portable format"
+resources.COMMAND_LINE_HELP_IMPORT = "import tasks and conditions from saved file [S]"
+resources.COMMAND_LINE_HELP_VERBOSE = "show verbose output for some options"
+resources.COMMAND_LINE_PREAMBLE = """\
+%s: %s - %s /
+When is a configurable user task scheduler for Ubuntu.
+The command line interface can be used to interact with running instances of
+When or to perform maintenance tasks. Use the --verbose option to read output
+from the command, as most operations will show no output by default.
+""" % (APPLET_NAME, APPLET_FULLNAME, APPLET_COPYRIGHT)
+resources.COMMAND_LINE_EPILOG = """\
+Note: options marked with [R] require an instance running in the background,
+with [S] require that no instance is running and with [N] have only effect
+after restart. Go to %s for more information.
+""" % APPLET_URL
 
 # constants for desktop entry and autostart entry
 APP_ENTRY_DESKTOP = """\
@@ -1148,6 +1174,7 @@ def dict_to_Task(d):
     t.case_sensitive = d['case_sensitive']
     t.command = d['command']
     t.startup_dir = d['startup_dir']
+    # TODO: if there are more parameters, use d.get('key', default_val)
     return t
 
 
@@ -1331,6 +1358,7 @@ def Condition_to_dict(c):
 def dict_to_Condition(d, c=None):
     if d['type'] != 'condition':
         raise ValueError("incorrect dictionary type")
+    # this will raise an error
     if c is None:
         c = Condition()
     c.cond_id = d['cond_id']
@@ -1339,6 +1367,7 @@ def dict_to_Condition(d, c=None):
     c.repeat = d['repeat']
     c.exec_sequence = d['exec_sequence']
     c.suspended = d['suspended']
+    # TODO: if there are more parameters, use d.get('key', default_val)
     return c
 
 
@@ -1371,6 +1400,7 @@ def dict_to_IntervalBasedCondition(d):
         raise ValueError("incorrect dictionary type")
     name = d['cond_name']
     interval = d['interval']
+    # TODO: if there are more parameters, use d.get('key', default_val)
     c = IntervalBasedCondition(name, interval)
     c = dict_to_Condition(d, c)
     return c
@@ -1429,6 +1459,8 @@ def dict_to_TimeBasedCondition(d):
     if d['type'] != 'condition' or d['subtype'] != 'TimeBasedCondition':
         raise ValueError("incorrect dictionary type")
     name = d['cond_name']
+    # we can use d for timedict because the needed keys (intentionally) match
+    # TODO: if there are more parameters, use d.get('key', default_val)
     c = TimeBasedCondition(name, d)
     c = dict_to_Condition(d, c)
     return c
@@ -1542,6 +1574,7 @@ def dict_to_CommandBasedCondition(d):
     status = d['expected_status']
     stdout = d['expected_stdout']
     stderr = d['expected_stderr']
+    # TODO: if there are more parameters, use d.get('key', default_val)
     c = CommandBasedCondition(name, command, status, stdout, stderr)
     c = dict_to_Condition(d, c)
     return c
@@ -1583,6 +1616,7 @@ def dict_to_IdleTimeBasedCondition(d):
         raise ValueError("incorrect dictionary type")
     name = d['cond_name']
     idle_secs = d['idle_secs']
+    # TODO: if there are more parameters, use d.get('key', default_val)
     c = IdleTimeBasedCondition(name, idle_secs)
     c = dict_to_Condition(d, c)
     return c
@@ -1621,6 +1655,7 @@ def dict_to_EventBasedCondition(d):
     name = d['cond_name']
     event = d['event']
     no_skip = d['no_skip']
+    # TODO: if there are more parameters, use d.get('key', default_val)
     c = EventBasedCondition(name, event, no_skip)
     c = dict_to_Condition(d, c)
     return c
@@ -2987,66 +3022,70 @@ if __name__ == '__main__':
             sys.exit(2)
         start()
     else:
-        parser = argparse.ArgumentParser()
-        parser.add_argument(
-            '-V', '--version',
-            dest='version', action='store_true',
-            help="show applet version"
-        )
-        parser.add_argument(
-            '-S', '--show-settings',
-            dest='show_settings', action='store_true',
-            help="show settings dialog box (when running)"
-        )
-        parser.add_argument(
-            '-R', '--reset-config',
-            dest='reset_config', action='store_true',
-            help="reset general configuration to default (when shut down)"
-        )
-        parser.add_argument(
-            '-I', '--show-icon',
-            dest='show_icon', action='store_true',
-            help="show applet icon (requires restart)"
-        )
-        parser.add_argument(
-            '-C', '--clear',
-            dest='clear', action='store_true',
-            help="clear all tasks and conditions (when shut down)"
-        )
-        parser.add_argument(
-            '-Q', '--query',
-            dest='query', action='store_true',
-            help="query for a running instance"
-        )
-        parser.add_argument(
-            '--shutdown',
-            dest='shutdown', action='store_true',
-            help="perform shutdown tasks and close an existing istance"
-        )
-        parser.add_argument(
-            '--kill',
-            dest='kill', action='store_true',
-            help="kill an existing istance (when running)"
-        )
-        parser.add_argument(
-            '-T', '--install',
-            dest='install', action='store_true',
-            help="install application icons and autostart, and exit"
-        )
-        parser.add_argument(
-            '--export',
-            dest='export_items', metavar='FILE', nargs='?', const='*',
-            help="save tasks and conditions to a portable format"
-        )
-        parser.add_argument(
-            '--import',
-            dest='import_items', metavar='FILE', nargs='?', const='*',
-            help="clear tasks and conditions and import from saved file"
+        parser = argparse.ArgumentParser(
+            prog=APPLET_NAME,
+            description=resources.COMMAND_LINE_PREAMBLE,
+            epilog=resources.COMMAND_LINE_EPILOG,
         )
         parser.add_argument(
             '-v', '--verbose',
             dest='verbose', action='store_true',
-            help="show verbose output for some options"
+            help=resources.COMMAND_LINE_HELP_VERBOSE
+        )
+        parser.add_argument(
+            '-V', '--version',
+            dest='version', action='store_true',
+            help=resources.COMMAND_LINE_HELP_VERSION
+        )
+        parser.add_argument(
+            '-S', '--show-settings',
+            dest='show_settings', action='store_true',
+            help=resources.COMMAND_LINE_HELP_SHOW_SETTINGS
+        )
+        parser.add_argument(
+            '-R', '--reset-config',
+            dest='reset_config', action='store_true',
+            help=resources.COMMAND_LINE_HELP_RESET_CONFIG
+        )
+        parser.add_argument(
+            '-I', '--show-icon',
+            dest='show_icon', action='store_true',
+            help=resources.COMMAND_LINE_HELP_SHOW_ICON
+        )
+        parser.add_argument(
+            '-C', '--clear',
+            dest='clear', action='store_true',
+            help=resources.COMMAND_LINE_HELP_CLEAR
+        )
+        parser.add_argument(
+            '-T', '--install',
+            dest='install', action='store_true',
+            help=resources.COMMAND_LINE_HELP_INSTALL
+        )
+        parser.add_argument(
+            '-Q', '--query',
+            dest='query', action='store_true',
+            help=resources.COMMAND_LINE_HELP_QUERY
+        )
+        parser.add_argument(
+            '--shutdown',
+            dest='shutdown', action='store_true',
+            help=resources.COMMAND_LINE_HELP_SHUTDOWN
+        )
+        parser.add_argument(
+            '--kill',
+            dest='kill', action='store_true',
+            help=resources.COMMAND_LINE_HELP_KILL
+        )
+        parser.add_argument(
+            '--export',
+            dest='export_items', metavar='FILE', nargs='?', const='*',
+            help=resources.COMMAND_LINE_HELP_EXPORT
+        )
+        parser.add_argument(
+            '--import',
+            dest='import_items', metavar='FILE', nargs='?', const='*',
+            help=resources.COMMAND_LINE_HELP_IMPORT
         )
 
         args = parser.parse_args()

--- a/when-command.py
+++ b/when-command.py
@@ -46,6 +46,7 @@ import pickle
 import logging
 import logging.config
 import logging.handlers
+import argparse
 import shutil
 import re
 
@@ -452,6 +453,10 @@ class Config(object):
             applet_log.warning("CONFIG: malformed configuration file, using default [%s]" % e)
             self._default()
             self.save()
+
+    def reset(self):
+        self._default()
+        self.save()
 
     def save(self):
         try:
@@ -2599,12 +2604,20 @@ def main():
 
 # implement the applet and start
 if __name__ == '__main__':
-    DBusGMainLoop(set_as_default=True)
-    create_desktop_file()
-    create_autostart_file(False)
-    GObject.threads_init()
-    applet = AppletIndicator()
-    main()
+    if len(sys.argv) == 1:
+        DBusGMainLoop(set_as_default=True)
+        create_desktop_file()
+        create_autostart_file(False)
+        GObject.threads_init()
+        applet = AppletIndicator()
+        main()
+    else:
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            '-R', '--reset-config',
+            dest='reset_config', action='store_true',
+            help="reset general configuration to default"
+        )
 
 
 # end.


### PR DESCRIPTION
This is a massive improvement, since it not only implements the required command line options, but in order to achieve this it also implements a way to send messages (through *DBus*) to a running instance of the applet. This allows the possibility to give the user more control (and in a more consistent way) on the running applet, removing the need for inelegant solutions such as the *Settings Dialog* pop-up when the applet si invoked twice. This release fixes #12 when pulled in.