### PR TITLE
Push system tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ to determine whether the process succeeded or failed. When choosing to check for
 
 There are several types of condition available:
 
-1. **Interval based**: After a certain time interval the associated tasks are executed, if the condition is set to repeat checks, the tasks will be executed again regularly after the same time interval.
-2. **Time based**: The tasks are executed when the time specification is matched. Time definitions can be partial, and in that case only the defined parts will be taken into account for checking: for instance, if the user only specifies minutes, the condition is verified at the specified minute for every hour.
-3. **Command based**: When the execution of a specified command gives the expected result (in terms of **exit code**, **stdout** or **stderr**), the tasks are executed. The way the test command is specified is similar (although simpler) to the specification of a command in the *Task* definition dialog box. The command is run in the same environment (and startup directory) as **When** at the moment it was started.
-4. **Idle time based**: When the session has been idle for the specified amount of time the tasks are executed. This actually is implemented as a shortcut to the command based condition built using the `xprintidle` command, which must be installed for the applet to work properly.
-5. **Event based**: The tasks are executed when a certain session or system event occurs. The following events are supported:
+1. **Interval based:** After a certain time interval the associated tasks are executed, if the condition is set to repeat checks, the tasks will be executed again regularly after the same time interval.
+2. **Time based:** The tasks are executed when the time specification is matched. Time definitions can be partial, and in that case only the defined parts will be taken into account for checking: for instance, if the user only specifies minutes, the condition is verified at the specified minute for every hour.
+3. **Command based:** When the execution of a specified command gives the expected result (in terms of **exit code**, **stdout** or **stderr**), the tasks are executed. The way the test command is specified is similar (although simpler) to the specification of a command in the *Task* definition dialog box. The command is run in the same environment (and startup directory) as **When** at the moment it was started.
+4. **Idle time based:** When the session has been idle for the specified amount of time the tasks are executed. This actually is implemented as a shortcut to the command based condition built using the `xprintidle` command, which must be installed for the applet to work properly.
+5. **Event based:** The tasks are executed when a certain session or system event occurs. The following events are supported:
   - *Startup* and *Shutdown*. These are verified when the applet (or session, if the applet is launched at startup) starts or quits.
   - *Suspend* and *Resume*, respectively match system suspension/hibernation and resume from a suspended state.
   - *Session Lock* and *Unlock*, that occur when the screen is locked or unlocked.
@@ -70,6 +70,8 @@ Also, the condition configuration interface allows to decide:
 * to *suspend* the condition: it will not be tested, but it's kept in the system, inactive until the *Suspend* box is unchecked.
 
 The selected condition (if any) can be deleted clicking the *Delete* button in the dialog box. Every condition must have an *unique name*, if a condition is named as an existing one it will replace it. The name *must* begin with an alphanumeric character (letter or digit) followed by alphanumerics, dashes and underscores.
+
+**Attention should be paid to events:** some events may not be supported on every platform, even on Ubuntu implementations. *Screen Lock/Unlock* for instance does not follow very precise specifications, and could be disabled on some desktops.
 
 
 ### The History window

--- a/README.md
+++ b/README.md
@@ -55,12 +55,13 @@ There are several types of condition available:
 4. **Idle time based**: When the session has been idle for the specified amount of time the tasks are executed. This actually is implemented as a shortcut to the command based condition built using the `xprintidle` command, which must be installed for the applet to work properly.
 5. **Event based**: The tasks are executed when a certain session or system event occurs. The following events are supported:
   - *Startup* and *Shutdown*. These are verified when the applet (or session, if the applet is launched at startup) starts or quits.
-  - *Suspend* and *Resume*, respectively matches on system suspension/hibernation and resume from a suspended state.
+  - *Suspend* and *Resume*, respectively match system suspension/hibernation and resume from a suspended state.
+  - *Session Lock* and *Unlock*, that occur when the screen is locked or unlocked.
   - *Screensaver*, both entering the screen saver state and exiting from it.
-  - *Storage Device Connect and Disconnect*, which take place when the user attaches or respectively detaches a removable storage device.
-  - *Join or Leave a Network*, these are verified whenever a network is joined or lost respectively.
+  - *Storage Device Connect* and *Disconnect*, which take place when the user attaches or respectively detaches a removable storage device.
+  - *Join* or *Leave a Network*, these are verified whenever a network is joined or lost respectively.
 
- *Warning*: because of the way applications are notified that the session is ending (first a TERM signal is sent, then a KILL if the first was unsuccessful), the *Shutdown* event is not suitable for long running tasks, such as file synchronizations, disk cleanup and similar actions. Longer running tasks will be run if the users quits the applet through the menu, though. Same yields for *Suspend*: by specification, no more than one second is available for tasks to complete. In reference to the event condition definition, one or more events might appear as *disabled* in the list: the user still can choose to create a condition based on a disabled event, but the corresponding tasks will never be run.
+ *Warning*: because of the way applications are notified that the session is ending (first a TERM signal is sent, then a KILL if the first was unsuccessful), the *Shutdown* event is not suitable for long running tasks, such as file synchronizations, disk cleanup and similar actions. Longer running tasks will be run if the users quits the applet through the menu, though. Same yields for *Suspend*: by specification, no more than one second is available for tasks to complete. In reference to the event condition definition, one or more events might appear as *[disabled]* in the list: the user still can choose to create a condition based on a disabled event, but the corresponding tasks will never be run.
 
 Also, the condition configuration interface allows to decide:
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ There are several types of condition available:
   - *Storage Device Connect and Disconnect*, which take place when the user attaches or respectively detaches a removable storage device.
   - *Join or Leave a Network*, these are verified whenever a network is joined or lost respectively.
 
- *Warning*: because of the way applications are notified that the session is ending (first a TERM signal is sent, then a KILL if the first was unsuccessful), the *Shutdown* event is not suitable for long running tasks, such as file synchronizations, disk cleanup and similar actions. Longer running tasks will be run if the users quits the applet through the menu, though. One or more events might appear as *disabled* in the list: the user still can choose to create a condition based on a disabled event, but it will never be verified.
+ *Warning*: because of the way applications are notified that the session is ending (first a TERM signal is sent, then a KILL if the first was unsuccessful), the *Shutdown* event is not suitable for long running tasks, such as file synchronizations, disk cleanup and similar actions. Longer running tasks will be run if the users quits the applet through the menu, though. Same yields for *Suspend*: by specification, no more than one second is available for tasks to complete. In reference to the event condition definition, one or more events might appear as *disabled* in the list: the user still can choose to create a condition based on a disabled event, but the corresponding tasks will never be run.
 
 Also, the condition configuration interface allows to decide:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,14 @@ There are several types of condition available:
 2. **Time based**: The tasks are executed when the time specification is matched. Time definitions can be partial, and in that case only the defined parts will be taken into account for checking: for instance, if the user only specifies minutes, the condition is verified at the specified minute for every hour.
 3. **Command based**: When the execution of a specified command gives the expected result (in terms of **exit code**, **stdout** or **stderr**), the tasks are executed. The way the test command is specified is similar (although simpler) to the specification of a command in the *Task* definition dialog box. The command is run in the same environment (and startup directory) as **When** at the moment it was started.
 4. **Idle time based**: When the session has been idle for the specified amount of time the tasks are executed. This actually is implemented as a shortcut to the command based condition built using the `xprintidle` command, which must be installed for the applet to work properly.
-5. **Event based**: The tasks are executed when a certain event occurs. Currently only *startup* and *shutdown* are the implemented events. *Warning*: because of the way applications are notified that the session is ending (first a TERM signal is sent, then a KILL if the first was unsuccessful), the *shutdown* event is not suitable for long running tasks, such as file synchronizations, disk cleanup and similar actions.
+5. **Event based**: The tasks are executed when a certain session or system event occurs. The following events are supported:
+  - *Startup* and *Shutdown*. These are verified when the applet (or session, if the applet is launched at startup) starts or quits.
+  - *Suspend* and *Resume*, respectively matches on system suspension/hibernation and resume from a suspended state.
+  - *Screensaver*, both entering the screen saver state and exiting from it.
+  - *Storage Device Connect and Disconnect*, which take place when the user attaches or respectively detaches a removable storage device.
+  - *Join or Leave a Network*, these are verified whenever a network is joined or lost respectively.
+
+ *Warning*: because of the way applications are notified that the session is ending (first a TERM signal is sent, then a KILL if the first was unsuccessful), the *Shutdown* event is not suitable for long running tasks, such as file synchronizations, disk cleanup and similar actions. Longer running tasks will be run if the users quits the applet through the menu, though. One or more events might appear as *disabled* in the list: the user still can choose to create a condition based on a disabled event, but it will never be verified.
 
 Also, the condition configuration interface allows to decide:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,11 +81,11 @@ List of achievements and expectations for the When applet.
 * Regexp match for shell command results (in both tasks and conditions) :ok:
 * Stop task sequence upon failure (or success) of one task :ok:
 * More system and session event conditions :ok:
-  - System suspend and/or resume :+1:
-  - Screen lock :+1:
+  - System suspend and/or resume :-1:
+  - Screen lock :-1:
   - Screensaver :+1:
   - Storage device attach/detach :+1:
-  - Join/Leave network :-1:
+  - Join/Leave network :+1:
 
 
 ## 2) To *Working* Alpha Release

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,7 @@ List of achievements and expectations for the When applet.
 * Stop task sequence upon failure (or success) of one task :ok:
 * More system and session event conditions :ok:
   - System suspend and/or resume :+1:
-  - Screen lock :-1:
+  - Screen lock :interrobang:
   - Screensaver :+1:
   - Storage device attach/detach :+1:
   - Join/Leave network :+1:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,7 +81,7 @@ List of achievements and expectations for the When applet.
 * Regexp match for shell command results (in both tasks and conditions) :ok:
 * Stop task sequence upon failure (or success) of one task :ok:
 * More system and session event conditions :ok:
-  - System suspend and/or resume :-1:
+  - System suspend and/or resume :+1:
   - Screen lock :-1:
   - Screensaver :+1:
   - Storage device attach/detach :+1:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,17 +50,17 @@ List of achievements and expectations for the When applet.
 * Delete condition :ok:
 * Resource strings (temporarily local, but moveable) :ok:
 * History box :ok:
-  1. History list with: :ok:
-    - Event time and duration :ok:
-    - Triggering condition :ok:
-    - Task name :ok:
-    - Task result (success/failure) :ok:
-    - Failure reason :ok:
+  1. History list with: :+1:
+    - Event time and duration :+1:
+    - Triggering condition :+1:
+    - Task name :+1:
+    - Task result (success/failure) :+1:
+    - Failure reason :+1:
   2. Task output pane (changes on list selection) :ok:
 * Single instance application (per user) :ok:
 * Better logging :ok:
-  - Remove excess and redundant cruft :ok:
-  - Log limits (size and backups) in configuration :ok:
+  - Remove excess and redundant cruft :+1:
+  - Log limits (size and backups) in configuration :+1:
 * Log management :ok:
 * Application icon :ok:
 * Application `.desktop` entry :ok:
@@ -69,17 +69,23 @@ List of achievements and expectations for the When applet.
 * Move initialization calls (not variables) to the `if __name__ == "__main__"` block
 * Dialog box design and refactoring :ok:
 * Command line switches (and configuration maintenance) :+1:
-  - Close current instance :ok:
-  - Open settings dialog :ok:
-  - Clear/Rebuild configuration directory :ok:
-  - Rewrite configuration :ok:
-  - Rewrite configuration and exit (via 2 switches) :ok:
-  - Install icons :ok:
-  - Force indicator icon on :ok:
-  - export tasks and conditions :ok:
-  - import tasks and conditions :ok:
+  - Close current instance  :+1:
+  - Open settings dialog  :+1:
+  - Clear/Rebuild configuration directory  :+1:
+  - Rewrite configuration  :+1:
+  - Rewrite configuration and exit (via 2 switches)  :+1:
+  - Install icons  :+1:
+  - Force indicator icon on  :+1:
+  - export tasks and conditions :+1:
+  - import tasks and conditions  :+1:
 * Regexp match for shell command results (in both tasks and conditions) :ok:
 * Stop task sequence upon failure (or success) of one task :ok:
+* More system and session event conditions :ok:
+  - System suspend and/or resume :+1:
+  - Screen lock :+1:
+  - Screensaver :+1:
+  - Storage device attach/detach :+1:
+  - Join/Leave network :-1:
 
 
 ## 2) To *Working* Alpha Release
@@ -99,12 +105,6 @@ List of achievements and expectations for the When applet.
 
 ## 5) To 1.0 *Production* Release
 
-* More system and session event conditions
-  - System suspend and/or resume
-  - Screen lock
-  - Device attach/detach
-  - Join network
-  - More to come
 * File watch conditions
 
 

--- a/share/when-command-edit-condition.glade
+++ b/share/when-command-edit-condition.glade
@@ -447,8 +447,18 @@
                             <property name="margin_left">15</property>
                             <property name="active_id">20</property>
                             <items>
-                              <item id="10" translatable="yes">Startup</item>
-                              <item id="20" translatable="yes">Shutdown</item>
+                              <item id="1" translatable="yes">Startup</item>
+                              <item id="2" translatable="yes">Shutdown</item>
+                              <item id="3" translatable="yes">Suspend</item>
+                              <item id="4" translatable="yes">Resume</item>
+                              <item id="5" translatable="yes">Connect Storage Device</item>
+                              <item id="6" translatable="yes">Disconnect Storage Device</item>
+                              <item id="7" translatable="yes">Join Network</item>
+                              <item id="8" translatable="yes">Leave Network</item>
+                              <item id="9" translatable="yes">Screensaver Started</item>
+                              <item id="10" translatable="yes">Return From Screensaver</item>
+                              <item id="11" translatable="yes">Session Lock</item>
+                              <item id="12" translatable="yes">Session Unlock</item>
                             </items>
                           </object>
                           <packing>

--- a/when-command.py
+++ b/when-command.py
@@ -615,7 +615,6 @@ def sysevent_condition_check(event, param=None):
     global current_system_event
     applet_lock.acquire()
     current_system_event = event
-    current_system_event_param = param
     applet_lock.release()
     try:
         if periodic.stopped:
@@ -627,7 +626,6 @@ def sysevent_condition_check(event, param=None):
     finally:
         applet_lock.acquire()
         current_system_event = None
-        current_system_event_param = None
         applet_lock.release()
 
 

--- a/when-command.py
+++ b/when-command.py
@@ -68,7 +68,7 @@ APPLET_FULLNAME = "When Gnome Scheduler"
 APPLET_SHORTNAME = "When"
 APPLET_COPYRIGHT = "(c) 2015 Francesco Garosi"
 APPLET_URL = "http://almostearthling.github.io/when-command/"
-APPLET_VERSION = "0.6.2-beta.5"
+APPLET_VERSION = "0.6.2-beta.6"
 APPLET_ID = "it.jks.WhenCommand"
 APPLET_BUS_NAME = '%s.BusService' % APPLET_ID
 APPLET_BUS_PATH = '/' + APPLET_BUS_NAME.replace('.', '/')
@@ -2917,7 +2917,7 @@ class AppletIndicator(Gtk.Application):
             # enabled_events.append(EVENT_SESSION_LOCK)
             # enabled_events.append(EVENT_SESSION_UNLOCK)
             self.lock_mgr = dbus.Interface(
-                self.system_bus.get_object('com.ubuntu.Upstart0_6', '/com/ubuntu/Upstart'),
+                self.session_bus.get_object('com.ubuntu.Upstart', '/com/ubuntu/Upstart'),
                 'com.ubuntu.Upstart0_6')
             self.lock_mgr.connect_to_signal('EventEmitted', self.upstart_lock_manager)
             enabled_events.append(EVENT_SESSION_LOCK)


### PR DESCRIPTION
This branch implements sensitivity to a lot of system and session events, in addition to *startup* and *shutdown*:

* *suspend* and *resume*
* storage device (eg. USB stick) attach or remove
* connect or disconnect from a network
* screensaver
* session lock and unlock

These events are captured via *DBus*, and are more than expected in the initial roadmap.
