### PR TITLE
Manage Items from the CLI

### DIFF
--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -917,7 +917,7 @@ class ItemDataFileInterpreter(object):
                     value = values.getint('interval minutes')
                     if value <= 0:
                         raise ValueError("invalid interval minutes: %s" % value)
-                    d['interval'] = value
+                    d['interval'] = value * 60
                 elif deftype == 'time':
                     d['year'] = None
                     d['month'] = None
@@ -1054,12 +1054,12 @@ class ItemDataFileInterpreter(object):
                     if 'event name' not in values:
                         raise ValueError("event name must be specified")
                     value = values['event name']
-                    if not VALIDATE_DBUS_NAME_RE.match(value):
+                    if not VALIDATE_SIGNAL_HANDLER_RE.match(value):
                         raise ValueError("invalid name for user event: '%s'"
                                          % value)
-                    d['type'] = 'event'
                     d['event'] = EVENT_DBUS_SIGNAL_PREAMBLE + ':' + value
                     d['no_skip'] = False
+                    print(d)
             elif item_type == 'signal_handler':
                 if not config.get('General', 'user events'):
                     raise ValueError("signal handlers are not enabled")
@@ -1194,6 +1194,7 @@ class ItemDataFileInterpreter(object):
                     item = dict_to_EventBasedCondition(item_dict)
                 elif subtype == 'PathNotifyBasedCondition':
                     item = dict_to_PathNotifyBasedCondition(item_dict)
+                print(item_dict)
                 new_conditions.append(item)
             elif item_type == 'task':
                 item = dict_to_Task(item_dict)
@@ -3939,11 +3940,11 @@ class ConditionDialog(object):
                 if cond.year:
                     o('txtYear').set_text(str(cond.year))
                 if cond.month:
-                    o('cbMonth').set_active_item(cond.month - 1)
+                    o('cbMonth').set_active(cond.month - 1)
                 if cond.day:
                     o('txtDay').set_text(str(cond.day))
                 if cond.weekday:
-                    o('cbWeekday').set_active_item(cond.weekday)
+                    o('cbWeekday').set_active(cond.weekday)
                 if cond.hour:
                     o('txtHour').set_text(str(cond.hour))
                 if cond.minute:

--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -122,6 +122,7 @@ VALIDATE_DBUS_NAME_RE = re.compile(r'^[-a-zA-Z_][-a-zA-Z0-9_]*(\.[-a-zA-Z_][-a-z
 VALIDATE_DBUS_PATH_RE = re.compile(r'^\/[a-zA-Z0-9_]+(\/[a-zA-Z0-9_]+)+$')
 VALIDATE_DBUS_INTERFACE_RE = re.compile(r'^[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)+\.?$')
 VALIDATE_DBUS_SIGNAL_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
+VALIDATE_DBUS_SUBPARAM_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
 
 # user interface constants
 UI_INTERVALS_MINUTES = [1, 2, 3, 5, 15, 30, 60]
@@ -776,7 +777,8 @@ class ItemDataFileInterpreter(object):
                 if not VALIDATE_TASK_RE.match(item_name):
                     raise ValueError("invalid name for task: '%s'" % item_name)
                 if 'command' not in values:
-                    raise ValueError("command not specified for task '%s'" % item_name)
+                    raise ValueError("command not specified for task '%s'"
+                                     % item_name)
                 d = {
                     'type': 'task',
                     'task_name': item_name,
@@ -803,7 +805,8 @@ class ItemDataFileInterpreter(object):
                         if x and '=' in x:
                             var, val = x.split('=', 1)
                             if not VALIDATE_ENVVAR_RE.match(var):
-                                raise ValueError("invalid variable name '%s'" % var)
+                                raise ValueError("invalid variable name '%s'"
+                                                 % var)
                             value[var] = val
                     d['environment_vars'] = value
                 if 'import environment' in values:
@@ -813,7 +816,8 @@ class ItemDataFileInterpreter(object):
                     if value.lower() == 'nothing':
                         d['success_status'] = None
                     else:
-                        outcome, source, value = map(str.strip, value.split(',', 2))
+                        outcome, source, value = map(str.strip,
+                                                     value.split(',', 2))
                         if source.lower() == 'status':
                             value = int(value)
                             if outcome.lower() == 'success':
@@ -822,7 +826,9 @@ class ItemDataFileInterpreter(object):
                                 d['success_status'] = None
                                 d['failure_status'] = value
                             else:
-                                raise ValueError("invalid outcome specification '%s'" % outcome)
+                                raise ValueError(
+                                    "invalid outcome specification '%s'"
+                                    % outcome)
                         else:
                             d['success_status'] = None
                             if source.lower() == 'stdout':
@@ -831,14 +837,18 @@ class ItemDataFileInterpreter(object):
                                 elif outcome.lower() == 'failure':
                                     d['failure_stdout'] = value
                                 else:
-                                    raise ValueError("invalid outcome specification '%s'" % outcome)
+                                    raise ValueError(
+                                        "invalid outcome specification '%s'"
+                                        % outcome)
                             elif source.lower() == 'stderr':
                                 if outcome.lower() == 'success':
                                     d['success_stderr'] = value
                                 elif outcome.lower() == 'failure':
                                     d['failure_stderr'] = value
                                 else:
-                                    raise ValueError("invalid outcome specification '%s'" % outcome)
+                                    raise ValueError(
+                                        "invalid outcome specification '%s'"
+                                        % outcome)
                             if 'exact match' in values:
                                 d['match_exact'] = values.getboolean('exact match')
                             if 'regexp match' in values:
@@ -850,7 +860,8 @@ class ItemDataFileInterpreter(object):
                     d['startup_dir'] = value
             elif item_type == 'condition':
                 if 'based on' not in values:
-                    raise ValueError("type not specified for condition '%s'" % item_name)
+                    raise ValueError("type not specified for condition '%s'"
+                                     % item_name)
                 deftype = values['based on'].lower()
                 subtype_map = {
                     'interval': 'IntervalBasedCondition',
@@ -863,11 +874,13 @@ class ItemDataFileInterpreter(object):
                     # TODO: add more type associations here
                 }
                 if deftype not in subtype_map:
-                    raise ValueError("incorrect condition type specified: '%s'" % deftype)
+                    raise ValueError("incorrect condition type specified: '%s'"
+                                     % deftype)
                 subtype = subtype_map[deftype]
                 task_list = []
                 if 'task names' in values:
-                    task_list = list(map(str.strip, values['task names'].split(',')))
+                    task_list = list(map(str.strip,
+                                         values['task names'].split(',')))
                     for x in task_list:
                         if not VALIDATE_TASK_RE.match(x):
                             raise ValueError("incorrect task name: '%s'" % x)
@@ -896,7 +909,8 @@ class ItemDataFileInterpreter(object):
                     elif value == 'failure':
                         d['break_failure'] = True
                     elif value != 'nothing':
-                        raise ValueError("condition break cause incorrect: '%s'" % value)
+                        raise ValueError("condition break cause incorrect: '%s'"
+                                         % value)
                 if deftype == 'interval':
                     if 'interval minutes' not in values:
                         raise ValueError("interval minutes must be specified")
@@ -954,7 +968,8 @@ class ItemDataFileInterpreter(object):
                         elif value in (7, 'sunday'):
                             d['weekday'] = 6
                         else:
-                            raise ValueError("incorrect weekday value: '%s'" % value)
+                            raise ValueError("incorrect weekday value: '%s'"
+                                             % value)
                 elif deftype == 'command':
                     if 'command' not in values:
                         raise ValueError("command must be specified")
@@ -977,7 +992,9 @@ class ItemDataFileInterpreter(object):
                             elif source == 'stderr':
                                 d['expected_stderr'] = value
                             else:
-                                raise ValueError("invalid source for outcome check: '%s'" % source)
+                                raise ValueError(
+                                    "invalid source for outcome check: '%s'"
+                                    % source)
                             if 'exact match' in values:
                                 d['match_exact'] = values.getboolean('exact match')
                             if 'regexp match' in values:
@@ -989,7 +1006,8 @@ class ItemDataFileInterpreter(object):
                         raise ValueError("idle minutes must be specified")
                     value = values.getint('idle minutes') * 60
                     if value <= 0:
-                        raise ValueError("invalid idle time: %s seconds" % value)
+                        raise ValueError("invalid idle time: %s seconds"
+                                         % value)
                     d['idle_secs'] = value
                 elif deftype == 'event':
                     if 'event type' not in values:
@@ -1001,15 +1019,18 @@ class ItemDataFileInterpreter(object):
                         'suspend': (EVENT_SYSTEM_SUSPEND, True),
                         'resume': (EVENT_SYSTEM_RESUME, False),
                         'connect_storage': (EVENT_SYSTEM_DEVICE_ATTACH, False),
-                        'disconnect_storage': (EVENT_SYSTEM_DEVICE_DETACH, False),
+                        'disconnect_storage': (EVENT_SYSTEM_DEVICE_DETACH,
+                                               False),
                         'join_network': (EVENT_SYSTEM_NETWORK_JOIN, False),
                         'leave_network': (EVENT_SYSTEM_NETWORK_LEAVE, False),
                         'screensaver': (EVENT_SESSION_SCREENSAVER, False),
-                        'exit_screensaver': (EVENT_SESSION_SCREENSAVER_EXIT, False),
+                        'exit_screensaver': (EVENT_SESSION_SCREENSAVER_EXIT,
+                                             False),
                         'lock': (EVENT_SESSION_LOCK, False),
                         'unlock': (EVENT_SESSION_UNLOCK, False),
                         'charging': (EVENT_SYSTEM_BATTERY_CHARGE, False),
-                        'discharging': (EVENT_SYSTEM_BATTERY_DISCHARGING, False),
+                        'discharging': (EVENT_SYSTEM_BATTERY_DISCHARGING,
+                                        False),
                         'battery_low': (EVENT_SYSTEM_BATTERY_LOW, False),
                         'command_line': (EVENT_COMMAND_LINE, False),
                         # TODO: add more predefined events here
@@ -1034,7 +1055,8 @@ class ItemDataFileInterpreter(object):
                         raise ValueError("event name must be specified")
                     value = values['event name']
                     if not VALIDATE_DBUS_NAME_RE.match(value):
-                        raise ValueError("invalid name for user event: '%s'" % value)
+                        raise ValueError("invalid name for user event: '%s'"
+                                         % value)
                     d['type'] = 'event'
                     d['event'] = EVENT_DBUS_SIGNAL_PREAMBLE + ':' + value
                     d['no_skip'] = False
@@ -1066,17 +1088,10 @@ class ItemDataFileInterpreter(object):
                     if value in ('session', 'system'):
                         d['bus'] = value
                     else:
-                        raise ValueError("incorrect value for bus: '%s'" % value)
+                        raise ValueError("incorrect value for bus: '%s'"
+                                         % value)
                 if 'defer' in values:
                     d['defer'] = values.getboolean('defer')
-                # to specify in documentation:
-                # parameters have the form
-                #  num[:sub],[not]operator,value
-                # where
-                # num is an int, sub either int or [a-zA-Z][0-9a-zA-Z_]+
-                # operator is a mnemonic: EQUAL, GT, LT, CONTAINS, MATCHES
-                # operator may be preceded by NOT
-                # operator and not are case insensitive
                 if 'parameters' in values:
                     param_list = values['parameters'].split('\n')
                     param_checks = []
@@ -1094,18 +1109,22 @@ class ItemDataFileInterpreter(object):
                                     sub = int(t[1])
                                 except ValueError:
                                     sub = t[1]
-                                    if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', sub):
-                                        raise ValueError("invalid value for parameter subindex: '%s'" % sub)
+                                    if not VALIDATE_DBUS_SUBPARAM_RE.match(sub):
+                                        raise ValueError(
+                                            "invalid value for parameter subindex: '%s'"
+                                            % sub)
                             t = oper.split()
                             neg = False
                             if len(t) == 2:
                                 if t[0] == 'not':
                                     neg = True
                                 else:
-                                    raise ValueError("incorrect operator: '%s'" % oper)
+                                    raise ValueError("incorrect operator: '%s'"
+                                                     % oper)
                                 oper = t[1]
                             elif len(t) > 2:
-                                raise ValueError("incorrect operator: '%s'" % oper)
+                                raise ValueError("incorrect operator: '%s'"
+                                                 % oper)
                             oper_map = {
                                 'equal': DBUS_CHECK_COMPARE_IS,
                                 'gt': DBUS_CHECK_COMPARE_GREATER,
@@ -1114,9 +1133,11 @@ class ItemDataFileInterpreter(object):
                                 'matches': DBUS_CHECK_COMPARE_MATCHES,
                             }
                             if oper not in oper_map:
-                                raise ValueError("incorrect operator: '%s'" % oper)
+                                raise ValueError("incorrect operator: '%s'"
+                                                 % oper)
                             o = oper_map[oper]
-                            param_checks.append(param_check(v, sub, o, neg, value))
+                            param_checks.append(param_check(v, sub, o, neg,
+                                                            value))
                     d['param_checks'] = param_checks
                     if 'verify' in values:
                         value = values['verify'].lower()
@@ -1125,13 +1146,15 @@ class ItemDataFileInterpreter(object):
                         elif value == 'any':
                             d['verify_all_checks'] = False
                         else:
-                            raise ValueError("incorrect verify value: '%s'" % value)
+                            raise ValueError("incorrect verify value: '%s'"
+                                             % value)
             # add the item dictionary to the temporary store
             store.append(d)
         # if we are here without raising exceptions, the only checks
         # still to be made are that conditions rely on existing items
         task_names = [d['task_name'] for d in store if 'task_name' in d]
-        sighandler_names = [d['handler_name'] for d in store if 'handler_name' in d]
+        sighandler_names = [
+            d['handler_name'] for d in store if 'handler_name' in d]
         if not ITEM_ADD_SELF_CONTAINED:
             task_names += tasks.names
             sighandler_names += signal_handlers.names

--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -1101,13 +1101,13 @@ class ItemDataFileInterpreter(object):
                                     raise ValueError("invalid value for parameter subindex: '%s'" % sub)
                         t = oper.split()
                         neg = False
-                        if len t == 2:
+                        if len(t) == 2:
                             if t[0] == 'not':
                                 neg = True
                             else:
                                 raise ValueError("incorrect operator: '%s'" % oper)
                             oper = t[1]
-                        elif t > 2:
+                        elif len(t) > 2:
                             raise ValueError("incorrect operator: '%s'" % oper)
                         oper_map = {
                             'equal': DBUS_CHECK_COMPARE_IS,

--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -1014,40 +1014,37 @@ class ItemDataFileInterpreter(object):
                         raise ValueError("event type must be specified")
                     value = values['event type'].lower()
                     event_map = {
-                        'startup': (EVENT_APPLET_STARTUP, False),
-                        'shutdown': (EVENT_APPLET_SHUTDOWN, True),
-                        'suspend': (EVENT_SYSTEM_SUSPEND, True),
-                        'resume': (EVENT_SYSTEM_RESUME, False),
-                        'connect_storage': (EVENT_SYSTEM_DEVICE_ATTACH, False),
-                        'disconnect_storage': (EVENT_SYSTEM_DEVICE_DETACH,
-                                               False),
-                        'join_network': (EVENT_SYSTEM_NETWORK_JOIN, False),
-                        'leave_network': (EVENT_SYSTEM_NETWORK_LEAVE, False),
-                        'screensaver': (EVENT_SESSION_SCREENSAVER, False),
-                        'exit_screensaver': (EVENT_SESSION_SCREENSAVER_EXIT,
-                                             False),
-                        'lock': (EVENT_SESSION_LOCK, False),
-                        'unlock': (EVENT_SESSION_UNLOCK, False),
-                        'charging': (EVENT_SYSTEM_BATTERY_CHARGE, False),
-                        'discharging': (EVENT_SYSTEM_BATTERY_DISCHARGING,
-                                        False),
-                        'battery_low': (EVENT_SYSTEM_BATTERY_LOW, False),
-                        'command_line': (EVENT_COMMAND_LINE, False),
+                        'startup': EVENT_APPLET_STARTUP,
+                        'shutdown': EVENT_APPLET_SHUTDOWN,
+                        'suspend': EVENT_SYSTEM_SUSPEND,
+                        'resume': EVENT_SYSTEM_RESUME,
+                        'connect_storage': EVENT_SYSTEM_DEVICE_ATTACH,
+                        'disconnect_storage': EVENT_SYSTEM_DEVICE_DETACH,
+                        'join_network': EVENT_SYSTEM_NETWORK_JOIN,
+                        'leave_network': EVENT_SYSTEM_NETWORK_LEAVE,
+                        'screensaver': EVENT_SESSION_SCREENSAVER,
+                        'exit_screensaver': EVENT_SESSION_SCREENSAVER_EXIT,
+                        'lock': EVENT_SESSION_LOCK,
+                        'unlock': EVENT_SESSION_UNLOCK,
+                        'charging': EVENT_SYSTEM_BATTERY_CHARGE,
+                        'discharging': EVENT_SYSTEM_BATTERY_DISCHARGING,
+                        'battery_low': EVENT_SYSTEM_BATTERY_LOW,
+                        'command_line': EVENT_COMMAND_LINE,
                         # TODO: add more predefined events here
                     }
                     if value not in event_map:
                         raise ValueError("invalid event type")
-                    event, no_skip = event_map[value]
+                    event = event_map[value]
                     if value == 'command_line':
                         event = EVENT_COMMAND_LINE_PREAMBLE + ':' + item_name
                     d['event'] = event
-                    d['no_skip'] = no_skip
+                    d['no_skip'] = True
                 elif deftype == 'file_change':
                     if 'watched path' not in values:
                         raise ValueError("watched path must be specified")
                     value = values['watched path']
                     d['watched_paths'] = [value]
-                    d['no_skip'] = False
+                    d['no_skip'] = True
                 elif deftype == 'user_event':
                     if not config.get('General', 'user events'):
                         raise ValueError("signal handlers are not enabled")
@@ -1058,7 +1055,7 @@ class ItemDataFileInterpreter(object):
                         raise ValueError("invalid name for user event: '%s'"
                                          % value)
                     d['event'] = EVENT_DBUS_SIGNAL_PREAMBLE + ':' + value
-                    d['no_skip'] = False
+                    d['no_skip'] = True
             elif item_type == 'signal_handler':
                 if not config.get('General', 'user events'):
                     raise ValueError("signal handlers are not enabled")

--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -1059,7 +1059,6 @@ class ItemDataFileInterpreter(object):
                                          % value)
                     d['event'] = EVENT_DBUS_SIGNAL_PREAMBLE + ':' + value
                     d['no_skip'] = False
-                    print(d)
             elif item_type == 'signal_handler':
                 if not config.get('General', 'user events'):
                     raise ValueError("signal handlers are not enabled")
@@ -1194,7 +1193,6 @@ class ItemDataFileInterpreter(object):
                     item = dict_to_EventBasedCondition(item_dict)
                 elif subtype == 'PathNotifyBasedCondition':
                     item = dict_to_PathNotifyBasedCondition(item_dict)
-                print(item_dict)
                 new_conditions.append(item)
             elif item_type == 'task':
                 item = dict_to_Task(item_dict)

--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -2293,7 +2293,7 @@ def dict_to_Task(d):
     t.startup_dir = d['startup_dir']
     # TODO: if there are more parameters, use d.get('key', default_val)
     t.match_regexp = d.get('match_regexp', False)
-    applet_log.info("MAIN: task %s restored" % t.task_name)
+    applet_log.info("MAIN: task %s loaded" % t.task_name)
     return t
 
 
@@ -2489,7 +2489,7 @@ def dict_to_Condition(d, c=None):
         raise ValueError("incorrect dictionary type")
     # this will raise an error
     if c is None:
-        applet_log.critical("MAIN: NTBS: attempt to restore base Condition")
+        applet_log.critical("MAIN: NTBS: attempt to load base Condition")
         c = Condition()
     applet_log.debug("MAIN: trying to load condition %s" % c.cond_name)
     c.cond_id = d['cond_id']
@@ -2538,7 +2538,7 @@ def dict_to_IntervalBasedCondition(d):
     # TODO: if there are more parameters, use d.get('key', default_val)
     c = IntervalBasedCondition(name, interval)
     c = dict_to_Condition(d, c)
-    applet_log.info("MAIN: restored interval based condition %s" % c.cond_name)
+    applet_log.info("MAIN: loaded interval based condition %s" % c.cond_name)
     return c
 
 
@@ -2602,7 +2602,7 @@ def dict_to_TimeBasedCondition(d):
     # TODO: if there are more parameters, use d.get('key', default_val)
     c = TimeBasedCondition(name, d)
     c = dict_to_Condition(d, c)
-    applet_log.info("MAIN: restored time based condition %s" % c.cond_name)
+    applet_log.info("MAIN: loaded time based condition %s" % c.cond_name)
     return c
 
 
@@ -2757,7 +2757,7 @@ def dict_to_CommandBasedCondition(d):
     c.match_regexp = match_regexp
     c.case_sensitive = case_sensitive
     c = dict_to_Condition(d, c)
-    applet_log.info("MAIN: restored command based condition %s" % c.cond_name)
+    applet_log.info("MAIN: loaded command based condition %s" % c.cond_name)
     return c
 
 
@@ -2807,7 +2807,7 @@ def dict_to_IdleTimeBasedCondition(d):
     # TODO: if there are more parameters, use d.get('key', default_val)
     c = IdleTimeBasedCondition(name, idle_secs)
     c = dict_to_Condition(d, c)
-    applet_log.info("MAIN: restored idle time based condition %s" % c.cond_name)
+    applet_log.info("MAIN: loaded idle time based condition %s" % c.cond_name)
     return c
 
 
@@ -2851,7 +2851,7 @@ def dict_to_EventBasedCondition(d):
     # TODO: if there are more parameters, use d.get('key', default_val)
     c = EventBasedCondition(name, event, no_skip)
     c = dict_to_Condition(d, c)
-    applet_log.info("MAIN: restored event based condition %s" % c.cond_name)
+    applet_log.info("MAIN: loaded event based condition %s" % c.cond_name)
     return c
 
 
@@ -2950,7 +2950,7 @@ def dict_to_PathNotifyBasedCondition(d):
     # TODO: if there are more parameters, use d.get('key', default_val)
     c = PathNotifyBasedCondition(name, event, no_skip)
     c = dict_to_Condition(d, c)
-    applet_log.info("MAIN: restored file change based condition %s" % c.cond_name)
+    applet_log.info("MAIN: loaded file change based condition %s" % c.cond_name)
     return c
 
 
@@ -3004,7 +3004,7 @@ def dict_to_DataCollectorBasedCondition(d, c=None):
     # TODO: if there are more parameters, use d.get('key', default_val)
     # the following will raise an error
     if c is None:
-        applet_log.critical("MAIN: NTBS: attempt to restore base DataCollectorBasedCondition")
+        applet_log.critical("MAIN: NTBS: attempt to load base DataCollectorBasedCondition")
         c = DataCollectorBasedCondition(name, no_skip)
     if no_skip:
         c.skip_seconds = 0
@@ -3422,7 +3422,7 @@ def dict_to_SignalHandler(d):
     h.verify_all_checks = d['verify_all_checks']
     h.defer = d['defer']
     # TODO: if there are more parameters, use d.get('key', default_val)
-    applet_log.info("MAIN: DBus signal handler %s restored" % h.handler_name)
+    applet_log.info("MAIN: DBus signal handler %s loaded" % h.handler_name)
     return h
 
 

--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -916,7 +916,7 @@ class ItemDataFileInterpreter(object):
                         raise ValueError("interval minutes must be specified")
                     value = values.getint('interval minutes')
                     if value <= 0:
-                        raise ValueError("invalid idle minutes: %s" % value)
+                        raise ValueError("invalid interval minutes: %s" % value)
                     d['interval'] = value
                 elif deftype == 'time':
                     d['year'] = None

--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -903,10 +903,12 @@ class ItemDataFileInterpreter(object):
                     elif value != 'nothing':
                         raise ValueError("condition break cause incorrect: '%s'" % value)
                 if subtype == 'interval':
-                    if 'interval minutes' in values:
-                        d['interval'] = values.getinteger('interval minutes')
-                    else:
+                    if 'interval minutes' not in values:
                         raise ValueError("interval minutes must be specified")
+                    value = values.getinteger('interval minutes')
+                    if value <= 0:
+                        raise ValueError("invalid idle minutes: %s" % value)
+                    d['interval'] = value
                 elif subtype == 'time':
                     d['year'] = None
                     d['month'] = None
@@ -917,13 +919,29 @@ class ItemDataFileInterpreter(object):
                     if 'year' in values:
                         d['year'] = values.getinteger('year')
                     if 'month' in values:
-                        d['month'] = values.getinteger('month')
+                        value = values.getinteger('month')
+                        if 1 <= value <= 12:
+                            d['month'] = value
+                        else:
+                            raise ValueError("invalid month: %s" % value)
                     if 'day' in values:
-                        d['day'] = values.getinteger('day')
+                        value = values.getinteger('day')
+                        if 1 <= value <= 31:
+                            d['day'] = value
+                        else:
+                            raise ValueError("invalid day: %s" % value)
                     if 'hour' in values:
-                        d['hour'] = values.getinteger('hour')
+                        value = values.getinteger('hour')
+                        if 0 <= value <= 23:
+                            d['hour'] = value
+                        else:
+                            raise ValueError("invalid hour: %s" % value)
                     if 'minute' in values:
-                        d['minute'] = values.getinteger('minute')
+                        value = values.getinteger('minute')
+                        if 0 <= value <= 59:
+                            d['minute'] = value
+                        else:
+                            raise ValueError("invalid minute: %s" % value)
                     if 'day of week' in values:
                         value = values['day of week'].lower()
                         if value in (1, 'monday'):
@@ -952,12 +970,6 @@ class ItemDataFileInterpreter(object):
                     d['expected_status'] = 0
                     d['expected_stdout'] = None
                     d['expected_stderr'] = None
-                    if 'exact match' in values:
-                        d['match_exact'] = values.getboolean('exact match')
-                    if 'regexp match' in values:
-                        d['match_regexp'] = values.getboolean('regexp match')
-                    if 'case sensitive' in values:
-                        d['case_sensitive'] = values.getboolean('case sensitive')
                     if 'check for' in values:
                         value = values['check for']
                         source, value = map(str.strip, value.split(',', 1))
@@ -971,10 +983,19 @@ class ItemDataFileInterpreter(object):
                                 d['expected_stderr'] = value
                             else:
                                 raise ValueError("invalid source for outcome check: '%s'" % source)
+                            if 'exact match' in values:
+                                d['match_exact'] = values.getboolean('exact match')
+                            if 'regexp match' in values:
+                                d['match_regexp'] = values.getboolean('regexp match')
+                            if 'case sensitive' in values:
+                                d['case_sensitive'] = values.getboolean('case sensitive')
                 elif subtype == 'idle_session':
                     if 'idle minutes' not in values:
                         raise ValueError("idle minutes must be specified")
-                    d['idle_secs'] = int(values['idle minutes']) * 60
+                    value = values.getinteger('idle minutes') * 60
+                    if value <= 0:
+                        raise ValueError("invalid idle minutes: %s" % value)
+                    d['idle_secs'] = value
                 elif subtype == 'event':
                     if 'event type' not in values:
                         raise ValueError("event type must be specified")

--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -1175,7 +1175,7 @@ class ItemDataFileInterpreter(object):
             elif item_type == 'task':
                 item = dict_to_Task(item_dict)
                 new_tasks.append(item)
-            elif item_type = 'dbus_signal_handler':
+            elif item_type == 'dbus_signal_handler':
                 item = dict_to_SignalHandler(item_dict)
                 new_signal_handlers.append(item)
         for item in new_signal_handlers:


### PR DESCRIPTION
This PR implements the requests in #61, #62 and #63. It allows to:

* specify items to be created and added to the currently managed items in a human-readable-and-editable file
* delete one item from the command line (if it's deletable)
* list all managed items, possibly limiting the type, to the console.

To do so this implementation adds the following command-line switches: `--item-add`, `--item-del` and `--item-list`.

Changes are reflected in a new branch of the documentation, with the same name. All current tests are passing, but new tests should be created to check the new features. Translations too must be updated for new text output.

Also, some quirks have been fixed that would have been difficult to spot without the possibility to handle big amounts of items at once by means of the *item definition file*.