### PR TITLE
Modular stock event definitions

### DIFF
--- a/share/man/man1/when-command.1
+++ b/share/man/man1/when-command.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "WHEN-COMMAND" "1" "December 21, 2015" "0.9" "When Documentation"
+.TH "WHEN-COMMAND" "1" "December 22, 2015" "0.9" "When Documentation"
 .SH NAME
 when-command \- When Documentation
 .
@@ -524,8 +524,8 @@ of the following and is \fImandatory\fP:
 \fBfile_change\fP when file or directory changes trigger the condition
 .IP \(bu 2
 \fBuser_event\fP for conditions arising on user defined events: these
-can only be used if user events are enable, otherwise the definition
-file is considered \fIinvalid\fP\&.
+can only be used if user events are enabled, otherwise the definition
+file is discarded.
 .UNINDENT
 .sp
 Any other value will invalidate the definition file.

--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -73,8 +73,8 @@ APPLET_LONGDESC = "When is a configurable user task scheduler for Gnome."
 # * the first holds the version ID that build utilities can extract
 # * the second one includes a message that is used both as a commit message
 #   and as a tag-associated message (in `git tag -m`)
-APPLET_VERSION = '0.9.4~beta.2'
-APPLET_TAGDESC = 'Provide minimalistic mode'
+APPLET_VERSION = '0.9.5~beta.1'
+APPLET_TAGDESC = 'Modular stock event management'
 
 # logging constants
 LOG_FORMAT = '%(asctime)s %(levelname)s: %(message)s'


### PR DESCRIPTION
This branch enables modular and streamlined definitions for stock events, as described in the comments for Issue #67, and the possibility to support fallback handlers in case the first choice handler fails to register. It thus enables more possibilities to support different distributions than Ubuntu, provided that in such distributions desktop system there is a DBus signal that can be interpreted as a trigger for the same type of event, thus opening the road to fix Issue #68 and more.