### PR TITLE
Fix 'ValueError: Namespace AppIndicator3 not available' on debian bullseye

### DIFF
--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -2223,7 +2223,7 @@ class Config(object):
             with open(self._config_file, mode='w') as f:
                 self._config_parser.write(f)
         except IOError as e:
-            applet_log.error("CONFIG: cannot write file %s [%s]" % (_config_file, _x(e)))
+            applet_log.error("CONFIG: cannot write file %s [%s]" % (self._config_file, _x(e)))
 
 
 # scheduler logic, see http://stackoverflow.com/a/18906292 for details
@@ -6635,7 +6635,7 @@ def call_show_box(box='about', verbose=False):
         oerr(resources.OERR_ERR_DBUS_SERVICE, verbose)
 
 
-def call_show_icon(show=True, running=True):
+def call_show_icon(show=True, running=True, verbose=False):
     if running:
         bus = dbus.SessionBus()
         proxy = bus.get_object(APPLET_BUS_NAME, APPLET_BUS_PATH)

--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -32,7 +32,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 try:
     gi.require_version('AppIndicator3', '0.1')
-except ValueError as e:
+except ValueError:
     gi.require_version('AyatanaAppIndicator3', '0.1')
 gi.require_version('Notify', '0.7')
 
@@ -41,7 +41,7 @@ from gi.repository import GObject
 from gi.repository import Gtk
 try:
     from gi.repository import AppIndicator3 as AppIndicator
-except ImportError as e:
+except ImportError:
     from gi.repository import AyatanaAppIndicator3 as AppIndicator
 from gi.repository import Notify
 from gi.repository import Pango

--- a/share/when-command/when-command.py
+++ b/share/when-command/when-command.py
@@ -30,13 +30,19 @@ import traceback
 
 import gi
 gi.require_version('Gtk', '3.0')
-gi.require_version('AppIndicator3', '0.1')
+try:
+    gi.require_version('AppIndicator3', '0.1')
+except ValueError as e:
+    gi.require_version('AyatanaAppIndicator3', '0.1')
 gi.require_version('Notify', '0.7')
 
 from gi.repository import GLib, Gio
 from gi.repository import GObject
 from gi.repository import Gtk
-from gi.repository import AppIndicator3 as AppIndicator
+try:
+    from gi.repository import AppIndicator3 as AppIndicator
+except ImportError as e:
+    from gi.repository import AyatanaAppIndicator3 as AppIndicator
 from gi.repository import Notify
 from gi.repository import Pango
 


### PR DESCRIPTION
In Debian Bullseye, AppIndicator3 is replaced with AyatanaAppIndicator3.