### PR TITLE
Fix SystemLoadCondition update process

### DIFF
--- a/lib/extra/sysload.py
+++ b/lib/extra/sysload.py
@@ -152,6 +152,7 @@ class form_SystemLoadCondition(form_Condition):
     # update the item from the form elements (usually update `tags`)
     def _updatedata(self):
         self._item.tags['treshold'] = self.data_get('treshold')
+        self._item.updateitem()
         return super()._updatedata()
 
 


### PR DESCRIPTION
Fix the way in which the "extra" SystemLoadCondition updates its data, so that it actually updates the base condition item parameters with the results derived from the specific ones