### PR TITLE
Fix parameter reset when clicking buttons

### DIFF
--- a/lib/forms/cond.py
+++ b/lib/forms/cond.py
@@ -139,6 +139,7 @@ class form_Condition(ApplicationForm):
         task = self.data_get('@choose_task')
         if task:
             self._tasks.append(task)
+        self._updatedata()
         self._updateform()
 
     def del_task(self):
@@ -146,6 +147,7 @@ class form_Condition(ApplicationForm):
         if elem:
             idx = int(elem[0])
             del self._tasks[idx]
+            self._updatedata()
             self._updateform()
 
     # def recall_task(self):
@@ -161,9 +163,9 @@ class form_Condition(ApplicationForm):
         self._tv_tasks.delete(*self._tv_tasks.get_children())
         if self._item:
             self.data_set('@name', self._item.name)
-            self.data_set('@recurring', bool(self._item.recurring))
-            self.data_set('@suspended', bool(self._item.suspended))
-            self.data_set('@execute_sequence', bool(self._item.execute_sequence))
+            self.data_set('@recurring', self._item.recurring or False)
+            self.data_set('@suspended', self._item.suspended or False)
+            self.data_set('@execute_sequence', self._item.execute_sequence if self._item.execute_sequence is False else True)
             idx = 0
             for task in self._tasks:
                 self._tv_tasks.insert('', iid="%s-%s" % (idx, task), values=(idx, task), index=tk.END)
@@ -188,9 +190,9 @@ class form_Condition(ApplicationForm):
         name = self.data_get('@name')
         if name is not None:
             self._item.name = name
-        self._item.recurring = self.data_get('@recurring')
-        self._item.suspended = self.data_get('@suspended')
-        self._item.execute_sequence = self.data_get('@execute_sequence')
+        self._item.recurring = self.data_get('@recurring') or None
+        self._item.suspended = self.data_get('@suspended') or None
+        self._item.execute_sequence = self.data_get('@execute_sequence') and None
         control_flow = self.data_get('@control_flow')
         if control_flow == 'break_failure':
             self._item.break_on_failure = True

--- a/lib/forms/cond_command.py
+++ b/lib/forms/cond_command.py
@@ -278,11 +278,11 @@ class form_CommandCondition(form_Condition):
         self.data_set('command', self._item.command)
         self.data_set('command_arguments', ' '.join(quote(x) for x in self._item.command_arguments) if self._item.command_arguments else None)
         self.data_set('startup_path', self._item.startup_path)
-        self.data_set('include_environment', self._item.include_environment)
-        self.data_set('set_environment_variables', self._item.set_environment_variables)
-        self.data_set('match_exact', self._item.match_exact)
-        self.data_set('case_sensitive', self._item.case_sensitive)
-        self.data_set('match_regular_expression', self._item.match_regular_expression)
+        self.data_set('include_environment', self._item.include_environment if self._item.include_environment is False else True)
+        self.data_set('set_environment_variables', self._item.set_environment_variables if self._item.set_environment_variables is False else True)
+        self.data_set('match_exact', self._item.match_exact or False)
+        self.data_set('case_sensitive', self._item.case_sensitive or False)
+        self.data_set('match_regular_expression', self._item.match_regular_expression or False)
         self.data_set('timeout_seconds', self._item.timeout_seconds or 0)
         self.data_set('check_after', self._item.check_after or 0)
         check_for = UI_OUTCOME_NONE
@@ -339,6 +339,7 @@ class form_CommandCondition(form_Condition):
                     e[l[0]] = str(l[1])
                 self._item.environment_variables = e or None
                 self._envvars.sort(key=lambda x: x[0])
+            self._updatedata()
             self._updateform()
 
     def del_var(self):
@@ -352,6 +353,7 @@ class form_CommandCondition(form_Condition):
         self._item.environment_variables = e or None
         # first update the form data, then recall the variable in the input
         # fields, so that the user can re-add the variable again if needed
+        self._updatedata()
         self._updateform()
         self.data_set('varname', name)
         self.data_set('newvalue', value)
@@ -364,9 +366,11 @@ class form_CommandCondition(form_Condition):
         self.data_set('newvalue', value)
 
     def browse_command(self):
+        # TODO: to be implemented
         pass
 
     def browse_startup_path(self):
+        # TODO: to be implemented
         pass
 
 

--- a/lib/forms/cond_lua.py
+++ b/lib/forms/cond_lua.py
@@ -131,6 +131,7 @@ class form_LuaScriptCondition(form_Condition):
                     e[l[0]] = str(l[1])
                 self._item.expected_results = e or None
                 self._results.sort(key=lambda x: x[0])
+                self._updatedata()
                 self._updateform()
         else:
             messagebox.showerror(UI_POPUP_T_ERR, UI_POPUP_INVALIDVARNAME)
@@ -146,6 +147,7 @@ class form_LuaScriptCondition(form_Condition):
         self._item.expected_results = e or None
         # first update the form data, then recall the variable in the input
         # fields, so that the user can re-add the variable again if needed
+        self._updatedata()
         self._updateform()
         self.data_set('varname', name)
         self.data_set('newvalue', value)
@@ -159,7 +161,7 @@ class form_LuaScriptCondition(form_Condition):
 
 
     def _updatedata(self):
-        self._item.script = self.data_get('script') or ""
+        self._item.script = self.data_get('script').strip() or ""
         self._item.expect_all = self.data_get('expect_all') or None
         self._item.check_after = self.data_get('check_after') or None
         e = {}
@@ -170,8 +172,8 @@ class form_LuaScriptCondition(form_Condition):
 
     def _updateform(self):
         self.data_set('script', self._item.script)
-        self.data_set('expect_all', self._item.expect_all)
-        self.data_set('check_after', self._item.check_after)
+        self.data_set('expect_all', self._item.expect_all or False)
+        self.data_set('check_after', self._item.check_after or '')
         self.data_set('varname')
         self.data_set('newvalue')
         self._results = []

--- a/lib/forms/cond_time.py
+++ b/lib/forms/cond_time.py
@@ -173,7 +173,7 @@ class form_TimeCondition(form_Condition):
         area_tslist = ttk.Frame(area)
         l_timeSpecs = ttk.Label(area_tslist, text=UI_FORM_CURRENTTIMESPECS_SC)
         # build a scrolled frame for the treeview
-        sftv_timeSpecs = ttk.Frame(area)
+        sftv_timeSpecs = ttk.Frame(area_tslist)
         tv_timeSpecs = ttk.Treeview(sftv_timeSpecs, columns=('seq', 'specs'), show='', displaycolumns=(1,), height=5)
         sb_timeSpecs = ttk.Scrollbar(sftv_timeSpecs, orient=tk.VERTICAL, command=tv_timeSpecs.yview)
         tv_timeSpecs.configure(yscrollcommand=sb_timeSpecs.set)
@@ -266,11 +266,14 @@ class form_TimeCondition(form_Condition):
             spec = None
         if spec:
             self._timespecs.append(spec)
+            self._updatedata()
+            self._updateform()
 
     def del_timespec(self):
         idx = self.data_get('timespec_selection')[0]
         del self._timespecs[idx]
-        self._updateform
+        self._updatedata()
+        self._updateform()
 
     def recall_timespec(self):
         sel = self.data_get('timespec_selection')
@@ -287,6 +290,7 @@ class form_TimeCondition(form_Condition):
     def clear_alltimespecs(self):
         # TODO: ask for confirmation
         self._timespecs = []
+        self._updatedata()
         self._updateform()
 
     def _updatedata(self):

--- a/lib/forms/task_command.py
+++ b/lib/forms/task_command.py
@@ -273,11 +273,11 @@ class form_CommandTask(form_Task):
         self.data_set('command', self._item.command)
         self.data_set('command_arguments', ' '.join(quote(x) for x in self._item.command_arguments) if self._item.command_arguments else None)
         self.data_set('startup_path', self._item.startup_path)
-        self.data_set('include_environment', self._item.include_environment)
-        self.data_set('set_environment_variables', self._item.set_environment_variables)
-        self.data_set('match_exact', self._item.match_exact)
-        self.data_set('case_sensitive', self._item.case_sensitive)
-        self.data_set('match_regular_expression', self._item.match_regular_expression)
+        self.data_set('include_environment', self._item.include_environment if self._item.include_environment is False else True)
+        self.data_set('set_environment_variables', self._item.set_environment_variables if self._item.set_environment_variables is False else True)
+        self.data_set('match_exact', self._item.match_exact or False)
+        self.data_set('case_sensitive', self._item.case_sensitive or False)
+        self.data_set('match_regular_expression', self._item.match_regular_expression or False)
         self.data_set('timeout_seconds', self._item.timeout_seconds or 0)
         check_for = UI_OUTCOME_NONE
         check_what = UI_EXIT_CODE
@@ -333,6 +333,7 @@ class form_CommandTask(form_Task):
                     e[l[0]] = str(l[1])
                 self._item.environment_variables = e or None
                 self._envvars.sort(key=lambda x: x[0])
+                self._updatedata()
                 self._updateform()
 
     def del_var(self):
@@ -346,6 +347,7 @@ class form_CommandTask(form_Task):
         self._item.environment_variables = e or None
         # first update the form data, then recall the variable in the input
         # fields, so that the user can re-add the variable again if needed
+        self._updatedata()
         self._updateform()
         self.data_set('varname', name)
         self.data_set('newvalue', value)
@@ -358,9 +360,11 @@ class form_CommandTask(form_Task):
         self.data_set('newvalue', value)
 
     def browse_command(self):
+        # TODO: to be implemented
         pass
 
     def browse_startup_path(self):
+        # TODO: to be implemented
         pass
 
 

--- a/lib/forms/task_lua.py
+++ b/lib/forms/task_lua.py
@@ -117,6 +117,7 @@ class form_LuaScriptTask(form_Task):
                     e[l[0]] = str(l[1])
                 self._item.expected_results = e or None
                 self._results.sort(key=lambda x: x[0])
+                self._updatedata()
                 self._updateform()
         else:
             messagebox.showerror(UI_POPUP_T_ERR, UI_POPUP_INVALIDVARNAME)
@@ -132,6 +133,7 @@ class form_LuaScriptTask(form_Task):
         self._item.expected_results = e or None
         # first update the form data, then recall the variable in the input
         # fields, so that the user can re-add the variable again if needed
+        self._updatedata()
         self._updateform()
         self.data_set('varname', name)
         self.data_set('newvalue', value)
@@ -145,7 +147,7 @@ class form_LuaScriptTask(form_Task):
 
 
     def _updatedata(self):
-        self._item.script = self.data_get('script') or ""
+        self._item.script = self.data_get('script').strip() or ""
         self._item.expect_all = self.data_get('expect_all') or None
         e = {}
         for l in self._results:
@@ -155,7 +157,7 @@ class form_LuaScriptTask(form_Task):
 
     def _updateform(self):
         self.data_set('script', self._item.script)
-        self.data_set('expect_all', self._item.expect_all)
+        self.data_set('expect_all', self._item.expect_all or False)
         self.data_set('varname')
         self.data_set('newvalue')
         self._results = []

--- a/lib/forms/ui.py
+++ b/lib/forms/ui.py
@@ -505,10 +505,13 @@ class ApplicationForm(object):
             if isinstance(widget, tk.Text):
                 s = widget.get(1.0, tk.END)
                 self._data[dataname].set(s)
-            rv = self._data[dataname].get()
-            if self._checks[dataname](rv):
-                return rv
-            else:
+            try:
+                rv = self._data[dataname].get()
+                if self._checks[dataname](rv):
+                    return rv
+                else:
+                    return None
+            except Exception as _:
                 return None
         else:
             return default


### PR DESCRIPTION
Fix the incorrect reset of item parameters in editor boxes when editing involves clicking a button. Also, some other fixes in UI (eg. displaced time specification box in time-based conditions) and better handling of default values in the generated configuration file. Closes #114.