### PR TITLE
Check and adjust item dependencies

### DIFF
--- a/lib/forms/cfgform.py
+++ b/lib/forms/cfgform.py
@@ -303,7 +303,21 @@ class form_Config(ApplicationForm):
                     new_item = e.run()
                     if new_item:
                         if new_item.name != item_name:
+                            # adjust dependencies
+                            for name in self._conditions:
+                                cond = self._conditions[name]
+                                if item_name in cond.tasks:
+                                    tasks = []
+                                    for t in cond.tasks:
+                                        if t == item_name:
+                                            tasks.append(new_item.name)
+                                        else:
+                                            tasks.append(t)
+                                    cond.tasks = tasks
+                                    self._conditions[name] = cond
+                            # remove the task with old name
                             del self._tasks[item_name]
+                        # add the new item or replace the existing one
                         self._tasks[new_item.name] = new_item
                         self._changed = True
 
@@ -316,7 +330,16 @@ class form_Config(ApplicationForm):
                     new_item = e.run()
                     if new_item:
                         if new_item.name != item_name:
+                            # adjust dependencies
+                            if new_item.type in ('event', 'bucket'):
+                                for name in self._events:
+                                    event = self._events[name]
+                                    if event.condition == item_name:
+                                        event.condition = new_item.name
+                                        self._events[name] = event
+                            # remove the condition with old name
                             del self._conditions[item_name]
+                        # add the new item or replace the existing one
                         self._conditions[new_item.name] = new_item
                         self._changed = True
 

--- a/lib/repocfg.py
+++ b/lib/repocfg.py
@@ -60,7 +60,7 @@ class _AppConfiguration(object):
 # to the type of release (eg. the DEBUG flag, see below)
 AppConfig = _AppConfiguration({
     # this flag should be set to False on normal operation
-    'DEBUG': False,
+    'DEBUG': True,
 
     # the application base name for configuration directory determination
     'CFGNAME': 'Whenever',


### PR DESCRIPTION
This commit avoids inconsistent configuration files that would be created when changing the name of items that are referenced in other items (tasks in conditions, conditions in events) by replacing the old names with the new ones in references too, as soon as an item is updated.