### PR TITLE
Implement the Refresh button in History box

### DIFF
--- a/lib/forms/history.py
+++ b/lib/forms/history.py
@@ -17,14 +17,14 @@ from ..icons import OUTCOME_UNKNOWN_ICON16x16 as UNK_ICON
 # form class: this form is fixed and will not be derived
 class form_History(ApplicationForm):
 
-    def __init__(self, history=None, main=False):
+    def __init__(self, wrapper, main=False):
 
         # the main tree view has an increased row size
         style = ttk.Style()
         style.configure('History.Treeview', rowheight=24)
 
         size = AppConfig.get('SIZE_HISTORY_FORM')
-        bbox = (BBOX_CLOSE,)
+        bbox = (BBOX_RELOAD, BBOX_CLOSE,)
         super().__init__(UI_TITLE_HISTORY, size, None, bbox, main)
 
         # list box icons
@@ -33,9 +33,9 @@ class form_History(ApplicationForm):
         self._icon_unknown = get_ui_image(UNK_ICON)
 
         # form data
+        self._wrapper = wrapper
         self._history = []
-        if history:
-            self.set_history(history)
+        self.set_history(self._wrapper.get_history())
 
         # build the UI: build widgets, arrange them in the box, bind data
 
@@ -116,6 +116,13 @@ class form_History(ApplicationForm):
         for entry, outcome in self._history:
             icon = self._icon_ok if outcome == 'OK' else self._icon_unknown if outcome == 'IND' else self._icon_fail
             self._tv_history.insert('', values=entry, index=ttk.END, image=icon)
+
+
+    # reload history data when the `reload` button is clicked
+    def reload(self):
+        self.set_history(self._wrapper.get_history())
+        self._updateform()
+        return super().reload()
 
 
 # end.

--- a/lib/i18n/strings_base.py
+++ b/lib/i18n/strings_base.py
@@ -4,7 +4,7 @@
 UI_APP = "When"
 UI_APP_LABEL = "When Automation Tool"
 UI_APP_COPYRIGHT = "© 2023-2025 Francesco Garosi"
-UI_APP_VERSION = "1.9.7b1"
+UI_APP_VERSION = "1.9.8b1"
 
 # item types
 ITEM_TASK = "Task"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "when"
-version = "1.9.7b1"
+version = "1.9.8b1"
 description = "Interface for the **whenever** automation tool"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 license = 'BSD 3-Clause "New" or "Revised" License'

--- a/when/when.py
+++ b/when/when.py
@@ -130,7 +130,7 @@ class App(object):
     # separate, detached thread so that it does not slow down the main loop
     def open_history(self, _):
         if self._window and self._wrapper:
-            form = form_History(self._wrapper.get_history())
+            form = form_History(self._wrapper)
             form.run()
             del form
 


### PR DESCRIPTION
This implements the refresh feature (actually a _Reload_ button, since it was available as stock button) so that, while the _History box_ is open, the button can be pressed and new entries are displayed. Closes #134.