### PR TITLE
Fix typos and bugs

### DIFF
--- a/lib/extra/c_sysload.py
+++ b/lib/extra/c_sysload.py
@@ -35,11 +35,11 @@ import shutil
 
 
 # resource strings (not internationalized)
-ITEM_HR_NAME = "System Load Below Treshold Condition"
+ITEM_HR_NAME = "System Load Below Threshold Condition"
 
 _UI_FORM_TITLE = "%s: System Load Condition Editor" % UI_APP
 
-_UI_FORM_SYSLOADTRESHOLD_SC = "Load is Below:"
+_UI_FORM_SYSLOADTHRESHOLD_SC = "Load is below:"
 
 
 # default values
@@ -89,7 +89,7 @@ class SystemLoadCondition(CommandCondition):
         else:
             self.tags = table()
             self.tags.append('subtype', self.subtype)
-            self.tags.append('treshold', _DEFAULT_LOW_LOAD_PERC)
+            self.tags.append('threshold', _DEFAULT_LOW_LOAD_PERC)
         self.updateitem()
 
     def updateitem(self):
@@ -97,14 +97,14 @@ class SystemLoadCondition(CommandCondition):
             self.command = "pwsh.exe"
             self.command_arguments = [
                 "-Command",
-                "If ((Get-CimInstance -Class Win32_Processor).LoadPercentage -lt %s) { echo OK }" % self.tags.get('treshold', _DEFAULT_LOW_LOAD_PERC),
+                "If ((Get-CimInstance -Class Win32_Processor).LoadPercentage -lt %s) { echo OK }" % self.tags.get('threshold', _DEFAULT_LOW_LOAD_PERC),
             ]
             self.success_stdout = "OK"
         elif sys.platform == 'linux':
             self.command = "bash"
             self.command_arguments = [
                 "-c",
-                "echo '%s <' `vmstat | tail -1 | awk '{print \$14}'` | bc" % self.tags.get('treshold', _DEFAULT_LOW_LOAD_PERC),
+                "echo '%s <' `vmstat | tail -1 | awk '{print \$14}'` | bc" % self.tags.get('threshold', _DEFAULT_LOW_LOAD_PERC),
             ]
             self.success_stdout = "1"
         self.startup_path = "."
@@ -130,13 +130,13 @@ class form_SystemLoadCondition(form_Condition):
         PAD = WIDGET_PADDING_PIXELS
 
         # build the UI elements as needed and configure the layout
-        l_treshold = ttk.Label(area, text=_UI_FORM_SYSLOADTRESHOLD_SC)
-        e_treshold = ttk.Entry(area)
+        l_threshold = ttk.Label(area, text=_UI_FORM_SYSLOADTHRESHOLD_SC)
+        e_threshold = ttk.Entry(area)
         l_percent = ttk.Label(area, text="%")
-        self.data_bind('treshold', e_treshold, TYPE_INT, lambda x: 0 < x < 100)
+        self.data_bind('threshold', e_threshold, TYPE_INT, lambda x: 0 < x < 100)
 
-        l_treshold.grid(row=0, column=0, sticky=tk.W, padx=PAD, pady=PAD)
-        e_treshold.grid(row=0, column=1, sticky=tk.NSEW, padx=PAD, pady=PAD)
+        l_threshold.grid(row=0, column=0, sticky=tk.W, padx=PAD, pady=PAD)
+        e_threshold.grid(row=0, column=1, sticky=tk.NSEW, padx=PAD, pady=PAD)
         l_percent.grid(row=0, column=2, sticky=tk.E, padx=PAD, pady=PAD)
 
         area.columnconfigure(1, weight=1)
@@ -147,12 +147,12 @@ class form_SystemLoadCondition(form_Condition):
 
     # update the form with the specific parameters (usually in the `tags`)
     def _updateform(self):
-        self.data_set('treshold', self._item.tags.get('treshold'))
+        self.data_set('threshold', self._item.tags.get('threshold'))
         return super()._updateform()
 
     # update the item from the form elements (usually update `tags`)
     def _updatedata(self):
-        self._item.tags['treshold'] = self.data_get('treshold')
+        self._item.tags['threshold'] = self.data_get('threshold')
         self._item.updateitem()
         return super()._updatedata()
 

--- a/lib/forms/cond_command.py
+++ b/lib/forms/cond_command.py
@@ -1,5 +1,6 @@
 # command condition form
 
+import sys
 import os
 import re
 import shutil
@@ -199,10 +200,11 @@ class form_CommandCondition(form_Condition):
 
         # bind data to widgets
         self.data_bind('command', e_command, TYPE_STRING)
-        # the following would be optimal, but it is too strict
-        # self.data_bind('command', e_command, TYPE_STRING, _is_command)
         self.data_bind('command_arguments', e_args, TYPE_STRING)
-        self.data_bind('startup_path', e_startupPath, TYPE_STRING, _is_dir)
+        self.data_bind('startup_path', e_startupPath, TYPE_STRING)
+        # the following checks would be optimal, but are actually too strict
+        # self.data_bind('command', e_command, TYPE_STRING, _is_command)
+        # self.data_bind('startup_path', e_startupPath, TYPE_STRING, _is_dir)
         self.data_bind('check_after', e_checkAfter, TYPE_INT, lambda x: x >= 0)
         self.data_bind('ignore_persistent_success', ck_ignorePersistentSuccess)
         self.data_bind('include_environment', ck_preserveEnv)
@@ -380,12 +382,13 @@ class form_CommandCondition(form_Condition):
         self.data_set('newvalue', value)
 
     def browse_command(self):
-        exts = get_executable_extensions()
-        if exts:
-            execs_list = ' '.join(exts)
-        else:
-            execs_list = None
-        entry = filedialog.askopenfilename(parent=self.dialog, filetypes=[(UI_FILETYPE_EXECUTABLES, execs_list)])
+        filetypes=[(UI_FILETYPE_ALL, ".*")]
+        if sys.platform == "win32":
+            exts = get_executable_extensions()
+            if exts:
+                execs_list = ' '.join(exts)
+                filetypes.insert(0, (UI_FILETYPE_EXECUTABLES, execs_list))
+        entry = filedialog.askopenfilename(parent=self.dialog, filetypes=filetypes)
         if entry:
             self.data_set('command', entry)
 

--- a/lib/forms/task_command.py
+++ b/lib/forms/task_command.py
@@ -1,5 +1,6 @@
 # command task form
 
+import sys
 from os.path import normpath
 
 from ..i18n.strings import *
@@ -187,10 +188,11 @@ class form_CommandTask(form_Task):
 
         # bind data to widgets
         self.data_bind('command', e_command, TYPE_STRING)
-        # the following would be optimal, but it is too strict
-        # self.data_bind('command', e_command, TYPE_STRING, _is_command)
         self.data_bind('command_arguments', e_args, TYPE_STRING)
-        self.data_bind('startup_path', e_startupPath, TYPE_STRING, _is_dir)
+        self.data_bind('startup_path', e_startupPath, TYPE_STRING)
+        # the following checks would be optimal, but are actually too strict
+        # self.data_bind('command', e_command, TYPE_STRING, _is_command)
+        # self.data_bind('startup_path', e_startupPath, TYPE_STRING, _is_dir)
         self.data_bind('include_environment', ck_preserveEnv)
         self.data_bind('set_environment_variables', ck_setEnvVars)
         self.data_bind('envvar_selection', tv_vars)
@@ -363,12 +365,13 @@ class form_CommandTask(form_Task):
         self.data_set('newvalue', value)
 
     def browse_command(self):
-        exts = get_executable_extensions()
-        if exts:
-            execs_list = ' '.join(exts)
-        else:
-            execs_list = None
-        entry = filedialog.askopenfilename(parent=self.dialog, filetypes=[(UI_FILETYPE_EXECUTABLES, execs_list)])
+        filetypes=[(UI_FILETYPE_ALL, ".*")]
+        if sys.platform == "win32":
+            exts = get_executable_extensions()
+            if exts:
+                execs_list = ' '.join(exts)
+                filetypes.insert(0, (UI_FILETYPE_EXECUTABLES, execs_list))
+        entry = filedialog.askopenfilename(parent=self.dialog, filetypes=filetypes)
         if entry:
             self.data_set('command', entry)
 

--- a/lib/i18n/strings_base.py
+++ b/lib/i18n/strings_base.py
@@ -4,7 +4,7 @@
 UI_APP = "When"
 UI_APP_LABEL = "When Automation Tool"
 UI_APP_COPYRIGHT = "© 2023-2025 Francesco Garosi"
-UI_APP_VERSION = "1.9.8b1"
+UI_APP_VERSION = "1.9.9b1"
 
 # item types
 ITEM_TASK = "Task"
@@ -317,6 +317,7 @@ UI_TRAY_MENU_CONFIGURE = "Configurator..."
 
 # file type labels for Open File dialogs
 UI_FILETYPE_EXECUTABLES = "Executable files"
+UI_FILETYPE_ALL = "All files"
 
 
 # symbols

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "when"
-version = "1.9.8b1"
+version = "1.9.9b1"
 description = "Interface for the **whenever** automation tool"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 license = 'BSD 3-Clause "New" or "Revised" License'


### PR DESCRIPTION
Fixed a misspelled 'threshold' in system load based condition code: this breaks compatibility with existing configuration files they still work, but the threshold value should be entered once again and the configuration saved for it to be consistent. Also, fixed the dialog box that allows for executable file selection by adding an 'All Files' option: on Linux it is the only one that is available. A pedantic check for working directory in command based items has been removed: execution of commands may fail, but the check should not take place there, where it was located - or at least under different circumstances.

The changes work as intended on both Windows and Linux, and the compatibility issues do not actually break working configurations.