### PR TITLE
Display correct icon in taskbar

### DIFF
--- a/lib/i18n/strings_base.py
+++ b/lib/i18n/strings_base.py
@@ -4,7 +4,7 @@
 UI_APP = "When"
 UI_APP_LABEL = "When Automation Tool"
 UI_APP_COPYRIGHT = "© 2023-2025 Francesco Garosi"
-UI_APP_VERSION = "1.9.9b1"
+UI_APP_VERSION = "1.9.10b1"
 
 # item types
 ITEM_TASK = "Task"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "when"
-version = "1.9.9b1"
+version = "1.9.10b1"
 description = "Interface for the **whenever** automation tool"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 license = 'BSD 3-Clause "New" or "Revised" License'

--- a/when/when.py
+++ b/when/when.py
@@ -66,6 +66,11 @@ class App(object):
     # the icon is created **after** creating the root window, because a root
     # is needed to be active for this purpose
     def __init__(self):
+        # the following lines solve the wrong icon problem on Windows
+        if sys.platform == "win32":
+            import ctypes
+            myappid = 'when.python.application'
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
         self._window = get_tkroot()
         self._window.withdraw()
         self._icon = ImageTk.PhotoImage(get_image(APP_ICON))


### PR DESCRIPTION
On Windows, add code that force the correct icon to be displayed in the taskbar, instead of the Python/Pythonw interpreter icon. Closes issue: #109.