### PR TITLE
Monitor system wakeups to reset conditions

### DIFF
--- a/lib/forms/cond.py
+++ b/lib/forms/cond.py
@@ -12,9 +12,7 @@ from ..repocfg import AppConfig
 
 from ..items.cond import Condition
 
-
-# regular expression for item name checking
-_RE_VALIDNAME = re.compile("^[a-zA-Z_][a-zA-Z0-9_]*$")
+from ..utility import is_valid_item_name
 
 
 # condition box base class: since this is the class that will be used in
@@ -151,9 +149,7 @@ class form_Condition(ApplicationForm):
         self._area_specific.columnconfigure(index=0, weight=1)
 
         # bind data to widgets
-        self.data_bind(
-            "@name", e_itemName, TYPE_STRING, lambda x: _RE_VALIDNAME.match(x)
-        )
+        self.data_bind("@name", e_itemName, TYPE_STRING, is_valid_item_name)
         self.data_bind("@recurring", ck_itemRecurring)
         self.data_bind(
             "@max_tasks_retries", e_maxTasksRetries, TYPE_INT, lambda x: x >= -1

--- a/lib/forms/event.py
+++ b/lib/forms/event.py
@@ -12,9 +12,7 @@ from ..repocfg import AppConfig
 
 from ..items.event import Event
 
-
-# regular expression for item name checking
-_RE_VALIDNAME = re.compile("^[a-zA-Z_][a-zA-Z0-9_]*$")
+from ..utility import is_valid_item_name
 
 
 # event box base class: since this is the class that will be used in derived
@@ -65,9 +63,7 @@ class form_Event(ApplicationForm):
         area.rowconfigure(10, weight=1)
 
         # bind data to widgets
-        self.data_bind(
-            "@name", e_itemName, TYPE_STRING, lambda x: _RE_VALIDNAME.match(x)
-        )
+        self.data_bind("@name", e_itemName, TYPE_STRING, is_valid_item_name)
         self.data_bind("@condition", cb_associatedCondition, TYPE_STRING)
 
         # finally set the item

--- a/lib/forms/task.py
+++ b/lib/forms/task.py
@@ -12,9 +12,7 @@ from ..repocfg import AppConfig
 
 from ..items.task import Task
 
-
-# regular expression for item name checking
-_RE_VALIDNAME = re.compile("^[a-zA-Z_][a-zA-Z0-9_]*$")
+from ..utility import is_valid_item_name
 
 
 # task box base class: since this is the class that will be used in derived
@@ -57,9 +55,7 @@ class form_Task(ApplicationForm):
         area.columnconfigure(1, weight=1)
 
         # bind data to widgets
-        self.data_bind(
-            "@name", e_itemName, TYPE_STRING, lambda x: _RE_VALIDNAME.match(x)
-        )
+        self.data_bind("@name", e_itemName, TYPE_STRING, is_valid_item_name)
 
         # finally set the item
         if item:

--- a/lib/i18n/strings_base.py
+++ b/lib/i18n/strings_base.py
@@ -4,7 +4,7 @@
 UI_APP = "When"
 UI_APP_LABEL = "When Automation Tool"
 UI_APP_COPYRIGHT = "© 2023-2025 Francesco Garosi"
-UI_APP_VERSION = "1.10.1b1"
+UI_APP_VERSION = "1.10.2b1"
 
 # item types
 ITEM_TASK = "Task"

--- a/lib/i18n/strings_base.py
+++ b/lib/i18n/strings_base.py
@@ -350,7 +350,6 @@ SYM_UNKNOWN = "∅"
 
 
 
-
 # default strings for standard buttons
 BTN_OK = "OK"
 BTN_CANCEL = "Cancel"
@@ -455,10 +454,6 @@ CLI_APPICON_NAME_CONFIG = f"Configure {UI_APP}"
 CLI_APPICON_DESC_CONFIG = f"Standalone configuration utility for {UI_APP}"
 CLI_APPICON_NAME_START = f"Start {UI_APP}"
 CLI_APPICON_DESC_START = f"Launch the {CLI_WHENEVER} scheduler and controlling application {UI_APP}"
-
-# CLI_SYM_CROSSMARK = ":cross_mark:"
-# CLI_SYM_CHECKMARK = ":heavy_check_mark:"
-
 
 
 # end.

--- a/lib/internal/reset_conds_on_resume.py
+++ b/lib/internal/reset_conds_on_resume.py
@@ -65,20 +65,21 @@ if sys.platform.startswith("win"):
 # build the event for Linux platforms: see
 # https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.login1.html#Signals
 # for details
-# if sys.platform == "linux":
-if True:
+if sys.platform == "linux":
     from ..items.event_dbus import DBusEvent
     _event = DBusEvent()
     _event.name = _ITEM_NAMES
     _event.condition = _ITEM_NAMES
     _event.bus = ":system"
     _event.rule = (
-        "type=signal,"
-        "interface=org.freedesktop.login1.Manager,"
-        "sender=org.freedesktop.login1,"
-        "member=PrepareForSleep,"
+        "type='signal',"
+        "interface='org.freedesktop.login1.Manager',"
+        "sender='org.freedesktop.login1',"
+        "member='PrepareForSleep'"
     )
-    _event.parameter_check = '[{0, "eq", false}]'
+    _event.parameter_check = [
+        { 'index': 0, 'operator': "eq", 'value': False }
+    ]
 
 event_ResetConditionsOnResume = _event
 

--- a/lib/internal/reset_conds_on_resume.py
+++ b/lib/internal/reset_conds_on_resume.py
@@ -1,0 +1,95 @@
+# reset conditions on resume
+#
+# private items that enable the "Reset Conditions on Resume" feature: it is
+# achieved by creating
+#
+# - a private event that fires when the workstation resumes from sleep
+# - a private condition that the above event triggers
+# - a private task that runs the whenever internal `reset_conditions` command
+
+import sys
+import os
+
+from ..utility import get_private_item_name_prefix
+
+if sys.platform.startswith("win"):
+    from ..items.event_wmi import WMIEvent
+elif sys.platform == "linux":
+    from ..items.event_dbus import DBusEvent
+else:
+    raise OSError("unsupported platform")
+
+from ..items.cond_event import EventCondition
+from ..items.task_internal import InternalCommandTask
+
+
+_ITEM_NAMES = get_private_item_name_prefix() + "ResetConditionsOnResume"
+
+def name_ResetConditionsOnResume():
+    return _ITEM_NAMES
+
+
+# task and condition are the same for all platforms
+
+_task = InternalCommandTask()
+_task.name = _ITEM_NAMES
+_task.command = "reset_conditions"
+task_ResetConditionsOnResume = _task
+
+_cond = EventCondition()
+_cond.name = _ITEM_NAMES
+_cond.tasks = [_ITEM_NAMES]
+_cond.recurring = True
+_cond.suspended = False
+condition_ResetConditionsOnResume = _cond
+
+
+# if no platform is matched, event is None just to avoid complaints
+_event = None
+
+# build the event for Windows platforms: see
+# https://devblogs.microsoft.com/scripting/monitor-and-respond-to-windows-power-events-with-powershell/
+# for details
+if sys.platform.startswith("win"):
+    _SECONDS_TO_MONITOR = 15
+    _EVENT_RESUME = 7
+    _event = WMIEvent()
+    _event.name = _ITEM_NAMES
+    _event.condition = _ITEM_NAMES
+    _event.query = (
+        f"SELECT * FROM Win32_PowerManagementEvent"
+        f"  WITHIN {_SECONDS_TO_MONITOR}"
+        f"  WHERE EventType={_EVENT_RESUME}"
+    )
+
+# build the event for Linux platforms: see
+# https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.login1.html#Signals
+# for details
+# if sys.platform == "linux":
+if True:
+    from ..items.event_dbus import DBusEvent
+    _event = DBusEvent()
+    _event.name = _ITEM_NAMES
+    _event.condition = _ITEM_NAMES
+    _event.bus = ":system"
+    _event.rule = (
+        "type=signal,"
+        "interface=org.freedesktop.login1.Manager,"
+        "sender=org.freedesktop.login1,"
+        "member=PrepareForSleep,"
+    )
+    _event.parameter_check = '[{0, "eq", false}]'
+
+event_ResetConditionsOnResume = _event
+
+
+# only export useful stuff
+__all__ = [
+    "task_ResetConditionsOnResume",
+    "condition_ResetConditionsOnResume",
+    "event_ResetConditionsOnResume",
+    "name_ResetConditionsOnResume",
+]
+
+
+# end.

--- a/lib/items/cond.py
+++ b/lib/items/cond.py
@@ -16,7 +16,7 @@
 # configuration is loaded back.
 
 from tomlkit import table, items
-from ..utility import check_not_none, append_not_none, generate_item_name
+from ..utility import check_not_none, append_not_none, generate_item_name, is_private_item_name
 
 
 # base class for conditions: all condition items will have the same interface
@@ -65,6 +65,10 @@ class Condition(object):
         if 'subtype' in self.__dict__:
             s += ":%s" % self.subtype
         return s
+
+    @property
+    def private(self):
+        return is_private_item_name(self.name)
 
     def as_table(self):
         if not check_not_none(

--- a/lib/items/event.py
+++ b/lib/items/event.py
@@ -10,7 +10,7 @@
 # not known to the scheduler occur.
 
 from tomlkit import table, items
-from ..utility import check_not_none, append_not_none, generate_item_name
+from ..utility import check_not_none, append_not_none, generate_item_name, is_private_item_name
 
 
 # base class for event: all event items will have the same interface thus they
@@ -47,6 +47,10 @@ class Event(object):
         if 'subtype' in self.__dict__:
             s += ":%s" % self.subtype
         return s
+
+    @property
+    def private(self):
+        return is_private_item_name(self.name)
 
     def as_table(self):
         if not check_not_none(

--- a/lib/items/task.py
+++ b/lib/items/task.py
@@ -6,7 +6,7 @@
 # as per whenever documentation.
 
 from tomlkit import table, items
-from ..utility import check_not_none, append_not_none, generate_item_name
+from ..utility import check_not_none, append_not_none, generate_item_name, is_private_item_name
 
 
 # base class for tasks: all task items will have the same interface thus they
@@ -41,6 +41,10 @@ class Task(object):
         if 'subtype' in self.__dict__:
             s += ":%s" % self.subtype
         return s
+
+    @property
+    def private(self):
+        return is_private_item_name(self.name)
 
     def as_table(self):
         if not check_not_none(

--- a/lib/repocfg.py
+++ b/lib/repocfg.py
@@ -73,6 +73,9 @@ AppConfig = _AppConfiguration(
         # history queue length
         "HISTORY_LENGTH": 100,
 
+        # whether or not to reset conditions on workstation resume
+        "RESET_CONDS_ON_RESUME": True,
+
         # configuration window size
         "SIZE_MAIN_FORM": (960, 640),
 

--- a/lib/utility.py
+++ b/lib/utility.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 from base64 import b64decode
+import re
 
 from tomlkit import table
 from hashlib import blake2s
@@ -24,6 +25,14 @@ from .i18n.strings import *
 from .repocfg import AppConfig
 
 
+# a regular expression to check whether an user-given name is valid
+_RE_VALID_ITEM_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+# private item name prefix
+_PRIVATE_ITEM_PREFIX = "__When__private__"
+
+
 # the common Tk root
 _tkroot = tk.Tk()
 _console = Console(force_terminal=True)
@@ -38,6 +47,21 @@ def get_tkroot():
 # return the terminal console handled by the "rich" module
 def get_rich_console():
     return _console
+
+
+# return the prefix for private item names
+def get_private_item_name_prefix():
+    return _PRIVATE_ITEM_PREFIX
+
+
+# check whether a name indicates that an item is private
+def is_private_item_name(s: str):
+    return s.startswith(_PRIVATE_ITEM_PREFIX)
+
+
+# check whether an user-provided name is valid
+def is_valid_item_name(s: str):
+    return bool(_RE_VALID_ITEM_NAME.match(s)) and not is_private_item_name(s)
 
 
 # check that all passed arguments are not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "when"
-version = "1.10.1b1"
+version = "1.10.2b1"
 description = "Interface for the **whenever** automation tool"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 license = 'BSD 3-Clause "New" or "Revised" License'

--- a/when/when_bg.pyw
+++ b/when/when_bg.pyw
@@ -14,6 +14,7 @@ def run_bg():
                 "start",
                 "",
                 "/B",
+                "/min",
                 pythonw,
                 "-m",
                 "when.when",


### PR DESCRIPTION
Use WMI on Windows and DBus on Linux to monitor wakeups, and reset conditions when they take place: this solves #151.

On Windows the following WQL event query is used:

```text
SELECT * FROM Win32_PowerManagementEvent  WITHIN 15  WHERE EventType=7
```

and on Linux we have the following filter:

```text
type='signal',sender='org.freedesktop.login1',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'
```

which passes a `false` value when the system is waking up. When the event arises, the related condition is fired and it triggers the `reset_conditions` internal command. Thus, the feature is implemented without intervention on the scheduler code: the three items, all of which are named `__When__private__ResetConditionsOnResume` (which is a legal but unusual name, although it speaks enough for itself) are regular items that appear in the TOML configuration file.

This release would introduce `__When__private__` as a prefix for items that are used internally by **When** to implement certain features, and this should be mentioned in the documentation.

For the moment this is implemented as a mandatory setting, in a further release there should be the possibility to opt out by clearing a check box in the main configuration window.