### PR TITLE
Hide private tasks from history

### DIFF
--- a/lib/i18n/strings_base.py
+++ b/lib/i18n/strings_base.py
@@ -4,7 +4,7 @@
 UI_APP = "When"
 UI_APP_LABEL = "When Automation Tool"
 UI_APP_COPYRIGHT = "© 2023-2025 Francesco Garosi"
-UI_APP_VERSION = "1.10.4b1"
+UI_APP_VERSION = "1.10.5b1"
 
 # item types
 ITEM_TASK = "Task"

--- a/lib/runner/history.py
+++ b/lib/runner/history.py
@@ -4,6 +4,7 @@
 
 
 from datetime import datetime
+from ..utility import get_private_item_name_prefix
 
 
 class History(object):
@@ -12,6 +13,7 @@ class History(object):
         self._history = []
         self._maxlen = maxlen
         self._open_records_timing = {}
+        self._private_prefix = get_private_item_name_prefix()
 
     def append(self, record):
         time = record["header"]["time"]
@@ -25,7 +27,7 @@ class History(object):
         status = record["contents"]["message_type"]["status"]
         message = record["contents"]["message"]
         itemstr = "%s/%s" % (item, item_id)
-        if when == "HIST":
+        if when == "HIST" and not item.startswith(self._private_prefix):
             if status == "START":
                 self._open_records_timing[itemstr] = time
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "when"
-version = "1.10.4b1"
+version = "1.10.5b1"
 description = "Interface for the **whenever** automation tool"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 license = 'BSD 3-Clause "New" or "Revised" License'


### PR DESCRIPTION
Private tasks, that is the ones that **When** uses to implement certain features (at the moment: condition reset when the workstation resumes from sleep), are now hidden from the history box. Closes #155.