### PR TITLE
Fix #170 and #169

### DIFF
--- a/lib/forms/cfgform.py
+++ b/lib/forms/cfgform.py
@@ -29,19 +29,19 @@ from .newitem import form_NewItem
 # configuration box class
 class form_Config(ApplicationForm):
 
-    def __init__(self, root=None, main=False):
+    def __init__(self, app=None, main=False):
 
         # the root window: if not set this runs as the main app
         # and is aware that no scheduler is under control of this
         # application
-        self._root = root
+        self._app = app
 
         # the main tree view has an increased row size
         style = ttk.Style()
         style.configure("Items.Treeview", rowheight=30)
 
         size = AppConfig.get("SIZE_MAIN_FORM")
-        if self._root:
+        if self._app:
             bbox = (
                 BBOX_NEW,
                 BBOX_EDIT,
@@ -564,8 +564,8 @@ class form_Config(ApplicationForm):
     # main (hidden) application form
     def reload(self):
         if messagebox.askyesno(UI_POPUP_T_CONFIRM, UI_POPUP_RELOADCONFIG_Q):
-            if self._root:
-                self._root.send_event("<<SchedReloadConfig>>")
+            if self._app:
+                self._app.send_event("<<SchedReloadConfig>>")
         return super().reload()
 
     # modify the reaction to the quit button so that if the configuration

--- a/lib/forms/event_fschange.py
+++ b/lib/forms/event_fschange.py
@@ -137,12 +137,14 @@ class form_FilesystemChangeEvent(form_Event):
             self.data_set("item_monitor", entry)
 
     def add_fsitem(self):
+        self._updatedata()
         item = normpath(self.data_get("item_monitor"))
         if item and item not in self._watch:
             self._watch.append(item)
             self._updateform()
 
     def del_fsitem(self):
+        self._updatedata()
         e = self.data_get("item_monitor")
         if e:
             idx = self._watch.index(e)

--- a/lib/forms/menubox.py
+++ b/lib/forms/menubox.py
@@ -134,7 +134,7 @@ class BtnLeave(_btn_MenuEntry):
 # a proper tray icon menu: activated by a left click on the icon
 class form_MenuBox(ApplicationForm):
 
-    def __init__(self, main=False):
+    def __init__(self, app=None, main=False):
 
         style = ttk.Style()
         style.configure(style="menubutton.TButton", anchor=tk.W)
@@ -143,7 +143,7 @@ class form_MenuBox(ApplicationForm):
             UI_TITLE_MENU, AppConfig.get("SIZE_MENU_BOX"), None, (BBOX_CANCEL,), main
         )
         self._image = ImageTk.PhotoImage(get_image(APP_BITMAP))
-        self._root = None
+        self._app = app
 
         # build the UI: build widgets, arrange them in the box, bind data
         # client area
@@ -178,44 +178,41 @@ class form_MenuBox(ApplicationForm):
         # expand appropriate sections
         area.columnconfigure(1, weight=1)
 
-    def set_root(self, root):
-        self._root = root
-
     # menu reactions: all events are managed by the main application, and
     # therefore they are implemented as messages passed to the root window
     def on_configure(self):
-        if self._root:
-            self._root.send_event("<<OpenCfgApp>>")
+        if self._app:
+            self._app.send_event("<<OpenCfgApp>>")
 
     def on_about(self):
-        if self._root:
-            self._root.send_event("<<OpenAboutBox>>")
+        if self._app:
+            self._app.send_event("<<OpenAboutBox>>")
 
     def on_menu_box(self):
-        if self._root:
-            self._root.send_event("<<OpenMenuBox>>")
+        if self._app:
+            self._app.send_event("<<OpenMenuBox>>")
 
     def on_pause_scheduler(self):
-        if self._root:
-            self._root.send_event("<<SchedPause>>")
+        if self._app:
+            self._app.send_event("<<SchedPause>>")
 
     def on_resume_scheduler(self):
-        if self._root:
-            self._root.send_event("<<SchedResume>>")
+        if self._app:
+            self._app.send_event("<<SchedResume>>")
 
     def on_reset_conditions(self):
-        if self._root:
-            self._root.send_event("<<SchedResetConditions>>")
+        if self._app:
+            self._app.send_event("<<SchedResetConditions>>")
 
     def on_history(self):
-        if self._root:
-            self._root.send_event("<<OpenHistory>>")
+        if self._app:
+            self._app.send_event("<<OpenHistory>>")
 
     # this sends an EXIT event to the main loop, so that the invisible
     # main window is destroyed and all the cleanup is performed
     def on_exit(self):
-        if self._root:
-            self._root.send_exit()
+        if self._app:
+            self._app.send_exit()
 
 
 # end.

--- a/lib/i18n/strings.py
+++ b/lib/i18n/strings.py
@@ -15,7 +15,7 @@ UI_APP = "When"
 CLI_APP = "when"
 UI_APP_LABEL = "When Automation Tool"
 UI_APP_COPYRIGHT = "© 2023-2025 Francesco Garosi"
-UI_APP_VERSION = "1.10.11b2"
+UI_APP_VERSION = "1.10.11b3"
 
 # other strings that should not be translated
 UI_WHENEVER = "Whenever"

--- a/lib/runner/logger.py
+++ b/lib/runner/logger.py
@@ -36,11 +36,11 @@ _LOGFMT = "{time} ({application}) {level} {emitter} {action}{itemstr}: [{when}/{
 # for now a very basic logger: improvements will be rotation and persistence
 class Logger(object):
 
-    def __init__(self, filename, level, root=None):
+    def __init__(self, filename, level, app=None):
         self._logfile = open(filename, "w")
         self._level = level
         self._level_num = _LOGLEVELS.index(self._level)
-        self._root = root
+        self._app = app
 
     def log(self, record):
         time = record["header"]["time"]
@@ -77,17 +77,17 @@ class Logger(object):
                 self._logfile.flush()
             return False
         elif when == "BUSY":
-            if self._root:
+            if self._app:
                 if status == "YES":
-                    self._root.send_event("<<SchedSetBusy>>")
+                    self._app.send_event("<<SchedSetBusy>>")
                 else:
-                    self._root.send_event("<<SchedSetNotBusy>>")
+                    self._app.send_event("<<SchedSetNotBusy>>")
         elif when == "PAUSE":
-            if self._root:
+            if self._app:
                 if status == "YES":
-                    self._root.send_event("<<SchedSetPaused>>")
+                    self._app.send_event("<<SchedSetPaused>>")
                 else:
-                    self._root.send_event("<<SchedSetNotPaused>>")
+                    self._app.send_event("<<SchedSetNotPaused>>")
         else:
             if ln >= self._level_num:
                 self._logfile.write(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "when"
-version = "1.10.11b2"
+version = "1.10.11b3"
 description = "Interface for the **whenever** automation tool"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 license = 'BSD 3-Clause "New" or "Revised" License'

--- a/when/when.py
+++ b/when/when.py
@@ -86,10 +86,6 @@ class App(object):
         from lib.forms.cfgform import form_Config
         from lib.forms.history import form_History
 
-        # self.set_tray_icon_gray = lambda self, i: set_tray_icon_gray(i)
-        # self.set_tray_icon_busy = lambda self, i: set_tray_icon_busy(i)
-        # self.set_tray_icon_normal = lambda self, i: set_tray_icon_normal(i)
-        # self.show_about_box = lambda self: show_about_box()
         self.set_tray_icon_gray = set_tray_icon_gray
         self.set_tray_icon_busy = set_tray_icon_busy
         self.set_tray_icon_normal = set_tray_icon_normal
@@ -225,8 +221,7 @@ class App(object):
 
     def open_menubox(self, _):
         if self._window and self._wrapper:
-            form = self.form_MenuBox()
-            form.set_root(self)
+            form = self.form_MenuBox(self)
             form.run()
             del form
 


### PR DESCRIPTION
Disambiguate the app pointer in configuration form (and other objects): using `_root` instead of `_app` caused the pointer to be shadowed; also, set the item name in FS change event editor form before updating the list of watched files, so that it does not revert to the previous value.

Fixes #169
Fixes #170